### PR TITLE
[Feat] TrendingSection, UpcomingSection 구현 완료

### DIFF
--- a/src/api/tmdb.js
+++ b/src/api/tmdb.js
@@ -41,12 +41,41 @@ export async function fetchTrendingMovies() {
   }
 }
 
+// Movie Details
+export async function fetchMovieDetails(id) {
+  try {
+    const res = await fetch(
+      `https://api.themoviedb.org/3/movie/${id}?language=ko-KR`,
+      options
+    );
+    if (!res.ok) throw new Error("Failed to fetch movie details");
+    return await res.json();
+  } catch (err) {
+    console.log("Failed to fetch Movie Details", err);
+    throw err;
+  }
+}
+
+// Trending Movies With Runtime
+export async function fetchTrendingMoviesWithRuntime() {
+  const list = await fetchTrendingMovies();
+  const settled = await Promise.allSettled(
+    list.map((m) => fetchMovieDetails(m.id))
+  );
+
+  return list.map((m, i) => ({
+    ...m,
+    runtime:
+      settled[i].status === "fulfilled" ? settled[i].value.runtime : null,
+  }));
+}
+
 // Upcoming Movies
 export async function fetchUpcomingMovies() {
   try {
     const today = getToday();
     const response = await fetch(
-      `https://api.themoviedb.org/3/discover/movie?language=ko-KR&region=KR&sort_by=primary_release_date.asc&primary_release_date.gte=${today}&with_original_language=ko&page=1`,
+      `https://api.themoviedb.org/3/discover/movie?language=ko-KR&region=KR&sort_by=popularity.desc&primary_release_date.gte=${today}&with_original_language=ko&page=1`,
       options
     );
     const data = await response.json();

--- a/src/assets/icons/arrow-icon-next.svg
+++ b/src/assets/icons/arrow-icon-next.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" fill="#1ed5aa">
+                <path
+                d="M9 6l6 6-6 6"
+                stroke="#1ed5aa"
+                strokeWidth="2"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+</svg>

--- a/src/assets/icons/arrow-icon-prev.svg
+++ b/src/assets/icons/arrow-icon-prev.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" fill="#1ed5aa">
+                <path
+                d="M15 18l-6-6 6-6"
+                stroke="#1ed5aa"
+                strokeWidth="2"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+</svg>

--- a/src/assets/icons/popularity.svg
+++ b/src/assets/icons/popularity.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="14" height="14" fill="#1ed5aa">
+                        <path d="M12 2C10 5 6 7.5 6 13a6 6 0 1 0 12 0c0-2.5-1.5-5-3-7 0 1.5-1 3-2 4 0-3 1-5.5-1-8z" />
+
+</svg>

--- a/src/assets/icons/release.svg
+++ b/src/assets/icons/release.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="#1ed5aa">
+<path
+                          d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 0 0-2 2v14
+                          a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 
+                          16H5V9h14v11zm-9-9h2v2h-2v-2z"
+                        />
+</svg>

--- a/src/assets/icons/runtime.svg
+++ b/src/assets/icons/runtime.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="#1ed5aa">
+                        <path d="M15 1H9v2h6V1zm-3 4C7.03 5 3 9.03 3 14s4.03 9 9 9 9-4.03 9-9-4.03-9-9-9zm0 16a7 7 0 1 1 0-14 7 7 0 0 1 0 14zm.5-11H11v5l4.25 2.52.75-1.23-3.5-2.04V10z" />
+
+</svg>

--- a/src/assets/icons/vote.svg
+++ b/src/assets/icons/vote.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="#1ed5aa">
+                        <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z" />
+
+</svg>

--- a/src/assets/poster-default.svg
+++ b/src/assets/poster-default.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 750" role="img" aria-label="No Poster">
+  <defs>
+    <!-- 배경 -->
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2a2d33"/>
+      <stop offset="100%" stop-color="#1c1f22"/>
+    </linearGradient>
+  </defs>
+
+  <!-- 배경 -->
+  <rect width="500" height="750" fill="url(#bg)" />
+  <rect width="500" height="750" fill="url(#glow)" />
+
+  <!-- 외곽 필름 프레임 -->
+  <rect x="40" y="40" width="420" height="670" rx="8"
+        stroke="url(#frame)" stroke-width="3" fill="none" />
+
+  <!-- 중앙 카메라 아이콘 -->
+  <g transform="translate(150,280)">
+    <!-- 본체 -->
+    <rect x="20" y="40" width="160" height="100" rx="10" fill="#4b5055"/>
+    <!-- 상단 -->
+    <rect x="60" y="20" width="80" height="20" rx="4" fill="#5c6166"/>
+    <!-- 렌즈 -->
+    <circle cx="100" cy="90" r="30" fill="#2d3135"/>
+    <circle cx="100" cy="90" r="18" fill="#9aa0a6"/>
+    <circle cx="100" cy="90" r="8" fill="#c5c9cc"/>
+    <!-- 플래시 -->
+    <rect x="35" y="50" width="20" height="10" rx="2" fill="#7d8389"/>
+  </g>
+
+  <!-- 텍스트 -->
+  <text x="50%" y="600" text-anchor="middle" fill="#eaeaea" opacity="0.9"
+        font-family="system-ui, sans-serif" font-size="50" letter-spacing="2"
+        style="text-transform:uppercase;">No Poster</text>
+</svg>

--- a/src/components/sections/HeroSection/HeroSection.jsx
+++ b/src/components/sections/HeroSection/HeroSection.jsx
@@ -2,7 +2,6 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination, Autoplay, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/pagination";
-import "swiper/css/scrollbar";
 
 import { useEffect, useState, useRef } from "react";
 import { fetchHeroMovies, fetchTrailers } from "../../../api/tmdb";

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.css
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.css
@@ -1,3 +1,30 @@
+.nowplaying-section {
+  padding: 30px;
+}
+
+.nowplaying-header--bar {
+  position: relative;
+  padding-left: 14px;
+  margin-bottom: 6px;
+}
+.nowplaying-header--bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 4px;
+  border-radius: 2px;
+  background: var(--color-primary);
+}
+.nowplaying-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: #9aa0a6;
+  border-bottom: 1px solid #1ed5aa8a;
+  padding-bottom: 10px;
+}
+
 .poster-container {
   position: relative;
   overflow: hidden;

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.css
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.css
@@ -1,5 +1,5 @@
 .nowplaying-section {
-  padding: 30px;
+  padding: 100px;
 }
 
 .nowplaying-header--bar {
@@ -17,6 +17,10 @@
   border-radius: 2px;
   background: var(--color-primary);
 }
+.nowplaying-title {
+  font-size: 33px;
+}
+
 .nowplaying-desc {
   margin: 0 0 14px;
   font-size: 13px;

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.css
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.css
@@ -20,8 +20,8 @@
 .nowplaying-desc {
   margin: 0 0 14px;
   font-size: 13px;
-  color: #9aa0a6;
-  border-bottom: 1px solid #1ed5aa8a;
+  color: var(--color-gray-300);
+  border-bottom: 1px solid var(--color-primary-soft);
   padding-bottom: 10px;
 }
 

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
@@ -39,7 +39,10 @@ const NowPlayingSection = () => {
 
   return (
     <section className="nowplaying-section">
-      <h2>Now Playing</h2>
+      <div className="nowplaying-header nowplaying-header--bar">
+        <h2 className="nowplaying-title">Now Playing</h2>
+      </div>
+      <p className="nowplaying-desc">극장에서 상영 중인 최신 영화들</p>
 
       {trailer && (
         <TrailerModal

--- a/src/components/sections/TrendingSection/TrendingSection.css
+++ b/src/components/sections/TrendingSection/TrendingSection.css
@@ -1,0 +1,105 @@
+.trending-section {
+  position: relative;
+  padding: 30px;
+}
+
+.trending-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.trending-header--bar {
+  position: relative;
+  padding-left: 14px;
+  margin-bottom: 6px;
+}
+.trending-header--bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 4px;
+  border-radius: 2px;
+  background: var(--color-primary);
+}
+
+.trending-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: #9aa0a6;
+  border-bottom: 1px solid #1ed5aa8a;
+  padding-bottom: 10px;
+}
+
+.trending-nav {
+  display: flex;
+  gap: 8px;
+}
+
+.trending-prev,
+.trending-next {
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.57);
+}
+.trending-prev:hover,
+.trending-next:hover {
+  color: var(--color-primary);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.trend-card {
+  background: #151515;
+  overflow: hidden;
+}
+
+.trend-poster img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 2 / 3;
+}
+
+.trend-content {
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.trend-movie-title {
+  margin: 0 0 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  text-align: center;
+}
+
+.trend-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.trending-swiper .swiper {
+  padding: 4px 2px 6px;
+}

--- a/src/components/sections/TrendingSection/TrendingSection.css
+++ b/src/components/sections/TrendingSection/TrendingSection.css
@@ -1,6 +1,6 @@
 .trending-section {
   position: relative;
-  padding: 30px;
+  padding: 100px;
 }
 
 .trending-header {
@@ -23,6 +23,9 @@
   width: 4px;
   border-radius: 2px;
   background: var(--color-primary);
+}
+.trending-title {
+  font-size: 33px;
 }
 
 .trending-desc {

--- a/src/components/sections/TrendingSection/TrendingSection.css
+++ b/src/components/sections/TrendingSection/TrendingSection.css
@@ -28,8 +28,8 @@
 .trending-desc {
   margin: 0 0 14px;
   font-size: 13px;
-  color: #9aa0a6;
-  border-bottom: 1px solid #1ed5aa8a;
+  color: var(--color-gray-300);
+  border-bottom: 1px solid var(--color-primary-soft);
   padding-bottom: 10px;
 }
 
@@ -45,16 +45,16 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  border: 1px solid rgba(255, 255, 255, 0.57);
+  border: 1px solid var(--color-gray-300);
 }
 .trending-prev:hover,
 .trending-next:hover {
   color: var(--color-primary);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-pill);
 }
 
 .trend-card {
-  background: #151515;
+  background: var(--bg-card);
   overflow: hidden;
 }
 
@@ -94,7 +94,7 @@
   gap: 6px;
   padding: 4px 10px;
   border-radius: 5px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-pill);
   font-size: 12px;
   line-height: 1;
   white-space: nowrap;

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -1,5 +1,15 @@
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, A11y } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/navigation";
+
 import { useEffect, useState } from "react";
-import { fetchTrendingMovies } from "../../../api/tmdb";
+import { fetchTrendingMoviesWithRuntime } from "../../../api/tmdb";
+import "./TrendingSection.css";
+import arrowNext from "../../../assets/icons/arrow-icon-next.svg";
+import arrowPrev from "../../../assets/icons/arrow-icon-prev.svg";
+import vote from "../../../assets/icons/vote.svg";
+import runtime from "../../../assets/icons/runtime.svg";
 
 const TrendingSection = () => {
   const [data, setData] = useState([]);
@@ -7,7 +17,7 @@ const TrendingSection = () => {
   useEffect(() => {
     const fetchMovies = async () => {
       try {
-        const data = await fetchTrendingMovies();
+        const data = await fetchTrendingMoviesWithRuntime();
         setData(data);
       } catch (err) {
         console.error("fetchMovies failed:", err);
@@ -16,13 +26,75 @@ const TrendingSection = () => {
     fetchMovies();
   }, []);
 
+  function formatRuntime(mins) {
+    if (!mins && mins !== 0) return "-";
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return h ? `${h}h ${m}m` : `${m}m`;
+  }
+
   return (
-    <div>
-      <h3>TrendingSection</h3>
-      {data.map((movie) => (
-        <p key={movie.id}>{movie.title}</p>
-      ))}
-    </div>
+    <section className="trending-section">
+      <div className="trending-header trending-header--bar">
+        <h2 className="trending-title">Trending</h2>
+        <div className="trending-nav">
+          <button className="trending-prev">
+            <img src={arrowPrev} alt="이전 버튼" />
+          </button>
+          <button className="trending-next">
+            <img src={arrowNext} alt="다음 버튼" />
+          </button>
+        </div>
+      </div>
+      <p className="trending-desc">이번 주 전 세계에서 가장 주목받는 영화들</p>
+
+      <div className="trending-swiper">
+        <Swiper
+          modules={[Navigation, A11y]}
+          navigation={{ prevEl: ".trending-prev", nextEl: ".trending-next" }}
+          spaceBetween={20}
+          a11y={{ enabled: true }}
+          slidesPerView={5}
+          slidesPerGroup={5}
+          breakpoints={{
+            320: { slidesPerView: 1, slidesPerGroup: 1 },
+            640: { slidesPerView: 2, slidesPerGroup: 2 },
+            1024: { slidesPerView: 4, slidesPerGroup: 4 },
+            1280: { slidesPerView: 5, slidesPerGroup: 5 },
+          }}
+          rewind={true}
+        >
+          {data.map((movie) => (
+            <SwiperSlide key={movie.id}>
+              <div className="trend-card">
+                <div className="trend-poster">
+                  <img
+                    src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+                    alt={movie.title}
+                  />
+                </div>
+
+                <div className="trend-content">
+                  <h3 className="trend-movie-title">{movie.title}</h3>
+
+                  <div className="trend-meta">
+                    <div className="meta-pill">
+                      <img src={runtime} alt="런타임 아이콘" />
+                      <span>{formatRuntime(movie.runtime)}</span>
+                    </div>
+
+                    <div className="meta-pill">
+                      <img src={vote} alt="평점 아이콘" />
+                      <span>{(movie.vote_average ?? 0).toFixed(1)}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/sections/UpcomingSection/UpcomingSection.css
+++ b/src/components/sections/UpcomingSection/UpcomingSection.css
@@ -1,6 +1,6 @@
 .upcoming-section {
   position: relative;
-  padding: 30px;
+  padding: 100px;
 }
 
 .upcoming-header {
@@ -8,6 +8,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
+  font-size: ;
 }
 .upcoming-header--bar {
   position: relative;
@@ -23,6 +24,9 @@
   width: 4px;
   border-radius: 2px;
   background: var(--color-primary);
+}
+.upcoming-title {
+  font-size: 33px;
 }
 
 .upcoming-desc {

--- a/src/components/sections/UpcomingSection/UpcomingSection.css
+++ b/src/components/sections/UpcomingSection/UpcomingSection.css
@@ -1,0 +1,118 @@
+.upcoming-section {
+  position: relative;
+  padding: 30px;
+}
+
+.upcoming-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.upcoming-header--bar {
+  position: relative;
+  padding-left: 14px;
+  margin-bottom: 6px;
+}
+.upcoming-header--bar::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 4px;
+  border-radius: 2px;
+  background: var(--color-primary);
+}
+.upcoming-desc {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: #9aa0a6;
+  border-bottom: 1px solid #1ed5aa8a;
+  padding-bottom: 10px;
+}
+
+.upcoming-nav {
+  display: flex;
+  gap: 8px;
+}
+
+.upcoming-prev,
+.upcoming-next {
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 1px solid rgba(255, 255, 255, 0.57);
+}
+.upcoming-prev:hover,
+.upcoming-next:hover {
+  color: var(--color-primary);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.upcoming-card {
+  background: #151515;
+  overflow: hidden;
+}
+
+.upcoming-poster img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 2 / 3;
+}
+
+.poster-d-day {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: var(--color-primary);
+  color: black;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: 6px;
+  letter-spacing: 0.5px;
+  z-index: 5;
+}
+
+.upcoming-content {
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.upcoming-movie-title {
+  margin: 0 0 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  text-align: center;
+}
+
+.upcoming-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.upcoming-swiper .swiper {
+  padding: 4px 2px 6px;
+}

--- a/src/components/sections/UpcomingSection/UpcomingSection.css
+++ b/src/components/sections/UpcomingSection/UpcomingSection.css
@@ -24,11 +24,12 @@
   border-radius: 2px;
   background: var(--color-primary);
 }
+
 .upcoming-desc {
   margin: 0 0 14px;
   font-size: 13px;
-  color: #9aa0a6;
-  border-bottom: 1px solid #1ed5aa8a;
+  color: var(--color-gray-300);
+  border-bottom: 1px solid var(--color-primary-soft);
   padding-bottom: 10px;
 }
 
@@ -44,16 +45,16 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  border: 1px solid rgba(255, 255, 255, 0.57);
+  border: 1px solid var(--color-gray-300);
 }
 .upcoming-prev:hover,
 .upcoming-next:hover {
   color: var(--color-primary);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-pill);
 }
 
 .upcoming-card {
-  background: #151515;
+  background: var(--bg-card);
   overflow: hidden;
 }
 
@@ -75,7 +76,7 @@
   padding: 4px 8px;
   border-radius: 6px;
   letter-spacing: 0.5px;
-  z-index: 5;
+  z-index: var(--z-upcoming-dday);
 }
 
 .upcoming-content {
@@ -107,7 +108,7 @@
   gap: 6px;
   padding: 4px 10px;
   border-radius: 5px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-pill);
   font-size: 12px;
   line-height: 1;
   white-space: nowrap;

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -11,6 +11,7 @@ import arrowNext from "../../../assets/icons/arrow-icon-next.svg";
 import arrowPrev from "../../../assets/icons/arrow-icon-prev.svg";
 import release from "../../../assets/icons/release.svg";
 import popularity from "../../../assets/icons/popularity.svg";
+import noPoster from "../../../assets/poster-default.svg";
 
 const UpcomingSection = () => {
   const [data, setData] = useState([]);
@@ -63,7 +64,11 @@ const UpcomingSection = () => {
               <div className="upcoming-card">
                 <div className="upcoming-poster">
                   <img
-                    src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+                    src={
+                      movie.poster_path
+                        ? `https://image.tmdb.org/t/p/original/${movie.poster_path}`
+                        : noPoster
+                    }
                     alt={movie.title}
                   />
                   {movie.release_date && (

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -1,5 +1,16 @@
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, A11y } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/navigation";
+
 import { useEffect, useState } from "react";
 import { fetchUpcomingMovies } from "../../../api/tmdb";
+import { getDDay } from "../../../utils/date";
+import "./UpcomingSection.css";
+import arrowNext from "../../../assets/icons/arrow-icon-next.svg";
+import arrowPrev from "../../../assets/icons/arrow-icon-prev.svg";
+import release from "../../../assets/icons/release.svg";
+import popularity from "../../../assets/icons/popularity.svg";
 
 const UpcomingSection = () => {
   const [data, setData] = useState([]);
@@ -17,12 +28,72 @@ const UpcomingSection = () => {
   }, []);
 
   return (
-    <div>
-      <h3>UpcomingSection</h3>
-      {data.map((movie) => (
-        <p key={movie.id}>{movie.title}</p>
-      ))}
-    </div>
+    <section className="upcoming-section">
+      <div className="upcoming-header upcoming-header--bar">
+        <h2 className="upcoming-title">Upcoming</h2>
+        <div className="upcoming-nav">
+          <button className="upcoming-prev">
+            <img src={arrowPrev} alt="이전 버튼" />
+          </button>
+          <button className="upcoming-next">
+            <img src={arrowNext} alt="다음 버튼" />
+          </button>
+        </div>
+      </div>
+      <p className="upcoming-desc">개봉을 앞둔 기대작들</p>
+
+      <div className="upcoming-swiper">
+        <Swiper
+          modules={[Navigation, A11y]}
+          navigation={{ prevEl: ".upcoming-prev", nextEl: ".upcoming-next" }}
+          spaceBetween={20}
+          a11y={{ enabled: true }}
+          slidesPerView={5}
+          slidesPerGroup={5}
+          breakpoints={{
+            320: { slidesPerView: 1, slidesPerGroup: 1 },
+            640: { slidesPerView: 2, slidesPerGroup: 2 },
+            1024: { slidesPerView: 4, slidesPerGroup: 4 },
+            1280: { slidesPerView: 5, slidesPerGroup: 5 },
+          }}
+          rewind={true}
+        >
+          {data.map((movie) => (
+            <SwiperSlide key={movie.id}>
+              <div className="upcoming-card">
+                <div className="upcoming-poster">
+                  <img
+                    src={`https://image.tmdb.org/t/p/original/${movie.poster_path}`}
+                    alt={movie.title}
+                  />
+                  {movie.release_date && (
+                    <div className="poster-d-day">
+                      {getDDay(movie.release_date)}
+                    </div>
+                  )}
+                </div>
+
+                <div className="upcoming-content">
+                  <h3 className="upcoming-movie-title">{movie.title}</h3>
+
+                  <div className="upcoming-meta">
+                    <div className="meta-pill">
+                      <img src={release} alt="개봉일 아이콘" />
+                      <span>{movie.release_date}</span>
+                    </div>
+
+                    <div className="meta-pill">
+                      <img src={popularity} alt="인기도 아이콘" />
+                      <span>{Math.round(movie.popularity)}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </section>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 :root {
   /* Brand */
   --color-primary: #1ed5aa;
+  --color-primary-soft: #1ed5aa8a;
   --gradient-primary: linear-gradient(to right, #1ed5aa 0%, #01b3e4 100%);
   --gradient-primary-soft: linear-gradient(
     to right,
@@ -12,15 +13,19 @@
   /* Neutral */
   --color-gray-100: rgba(255, 255, 255, 0.53);
   --color-gray-200: rgba(128, 128, 128, 0.53);
+  --color-gray-300: #9aa0a6;
 
   /* Backgrounds */
   --bg-overlay: rgba(0, 0, 0, 1);
+  --bg-card: #151515;
+  --bg-pill: rgba(255, 255, 255, 0.08);
 
   /* Layers */
+  --z-upcoming-dday: 5;
   --z-hero-overlay: 100;
   --z-hero-content: 101;
-  --z-header: 1000;
   --z-trailer-modal: 500;
+  --z-header: 1000;
 }
 
 /* ===================== Reset ===================== */

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,5 +1,5 @@
 // YYYY-MM-DD 포맷 문자열로 변환
-function formatDate(date) {
+export function formatDate(date) {
   return date.toISOString().split("T")[0];
 }
 
@@ -13,4 +13,19 @@ export function getMonthsAgo(months) {
   const date = new Date();
   date.setMonth(date.getMonth() - months);
   return formatDate(date);
+}
+
+// 개봉일 D-Day
+export function getDDay(releaseDate) {
+  if (!releaseDate) return null;
+  const today = new Date();
+  const target = new Date(releaseDate);
+
+  // 날짜 차이 계산 (UTC 시간 차이 보정)
+  const diffTime = target.setHours(0, 0, 0, 0) - today.setHours(0, 0, 0, 0);
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays > 0) return `D-${diffDays}`;
+  if (diffDays === 0) return "D-Day";
+  return "개봉";
 }


### PR DESCRIPTION
### 👀 구현 화면
<img width="1880" height="821" alt="스크린샷 2025-10-13 144422" src="https://github.com/user-attachments/assets/086e74a0-d63a-4969-bdd8-638c10caf236" />
<img width="1882" height="825" alt="스크린샷 2025-10-13 144403" src="https://github.com/user-attachments/assets/b34b16dd-aa1c-48cf-b0ae-8c1732cbca93" />

---

### ✅ 변경사항
#### 1. NowPlayingSection 헤더 구조 개선
- **섹션 헤더 레이아웃 정비**
  - 타이틀과 설명, 구분선(bar) 스타일 개선  
  - 일관된 헤더 구조(`section-header--bar`)로 통일  

#### 2. TrendingSection 구현
- **API 연동**
  - `fetchTrendingMoviesWithRuntime()` 함수 사용 (영화별 runtime 포함)
- **레이아웃 및 스타일**
  - 카드형 슬라이드 레이아웃 구성  
  - 런타임·평점 메타 정보 표시 (`meta-pill`)  
  - Swiper 내비게이션(이전/다음) 버튼 적용  
  - 반응형 슬라이드 설정 (320~1280px 대응)

#### 3. UpcomingSection 구현
- **API 연동**
  - `fetchUpcomingMovies()` 활용  
  - 개봉일(`release_date`) 기반 **D-Day 계산** 함수(`getDDay`) 적용  
- **레이아웃 및 스타일**
  - 카드형 슬라이드 레이아웃 구성  
  - 개봉일·인기도 메타 정보 표시 (`meta-pill`)  
  - Swiper 내비게이션(이전/다음) 버튼 적용  
  - 반응형 슬라이드 설정 (320~1280px 대응)
  - D-Day 배지(`poster-d-day`) 스타일 구현 

#### 4. 스타일 시스템 개선
- **디자인 토큰 적용**
  - 색상 및 배경, 테두리 변수 추가 및 섹션 전반(Trending / Upcoming / NowPlaying)에서 토큰 일관 적용  
- **디폴트 포스터 이미지 추가**
  - 포스터 미존재 시 기본 이미지 표시로 예외 처리  
 
---

### ⭐ 이후 수정 사항
- 섹션별 공통 부분 컴포넌트로 분리 (헤더, swiper 등등) #18 
- 디폴트 이미지 전체 포스터에 적용 (현재 개봉 예정에만 적용함)