### PR TITLE
[Refactor] 섹션 데이터 fetch 로직 useHook화 리팩토링

### DIFF
--- a/src/components/sections/HeroSection/HeroSection.jsx
+++ b/src/components/sections/HeroSection/HeroSection.jsx
@@ -3,34 +3,20 @@ import { Pagination, Autoplay, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/pagination";
 
-import { useEffect, useState, useRef } from "react";
-import { fetchHeroMovies, fetchTrailers } from "../../../api/tmdb";
+import { useState, useRef } from "react";
+import { useHeroMovies } from "../../../hooks/useHeroMovies";
 import { useGenres } from "../../../hooks/useGenres";
+import { fetchTrailers } from "../../../api/tmdb";
 import "./HeroSection.css";
 import HeroSkeleton from "../skeleton/HeroSkeleton";
 import TrailerModal from "../NowPlayingSection/TrailerModal";
 import playIcon from "../../../assets/icons/play.svg";
 
 const HeroSection = () => {
-  const [data, setData] = useState([]);
+  const { data, loading } = useHeroMovies();
   const genreMap = useGenres(null);
   const [trailer, setTrailer] = useState("");
   const swiperRef = useRef(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchMovies = async () => {
-      try {
-        const data = await fetchHeroMovies();
-        setData(data);
-      } catch (err) {
-        console.error("fetchMovies failed:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMovies();
-  }, []);
 
   async function handleTrailerOpen(movie) {
     const url = await fetchTrailers(movie.id);

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
-import { fetchNowPlayingPagesWithTrailers } from "../../../api/tmdb";
+import { useState } from "react";
+import { useNowPlayingPagesWithTrailers } from "../../../hooks/useNowPlayingWithTrailers";
+
 import "./NowPlayingSection.css";
 import "../common/Section.css";
 import SectionHeader from "../common/SectionHeader";
@@ -7,10 +8,9 @@ import NowPlayingSkeleton from "../skeleton/NowPlayingSkeleton";
 import TrailerModal from "./TrailerModal";
 
 const NowPlayingSection = () => {
-  const [rows, setRows] = useState({ page1: [], page2: [] });
+  const { data: rows, loading } = useNowPlayingPagesWithTrailers();
   const [animate, setAnimate] = useState(true);
   const [trailer, setTrailer] = useState(""); // iframe src
-  const [loading, setLoading] = useState(true);
 
   const onStop = () => {
     if (!trailer) setAnimate(false);
@@ -18,20 +18,6 @@ const NowPlayingSection = () => {
   const onRun = () => {
     if (!trailer) setAnimate(true);
   };
-
-  useEffect(() => {
-    const fetchMovies = async () => {
-      try {
-        const data = await fetchNowPlayingPagesWithTrailers();
-        setRows(data);
-      } catch (err) {
-        console.error("fetchMovies failed:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMovies();
-  }, []);
 
   function handleTrailerOpen(movie) {
     setAnimate(false);

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -3,8 +3,8 @@ import { Navigation, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 
-import { useEffect, useState } from "react";
-import { fetchTrendingMoviesWithRuntime } from "../../../api/tmdb";
+import { useState } from "react";
+import { useTrendingMoviesWithRuntime } from "../../../hooks/useTrendingMoviesWithRuntime"; // ✅ 신규 훅
 import "./TrendingSection.css";
 import "../common/Section.css";
 import SectionHeader from "../common/SectionHeader";
@@ -15,23 +15,8 @@ import vote from "../../../assets/icons/vote.svg";
 import runtime from "../../../assets/icons/runtime.svg";
 
 const TrendingSection = () => {
-  const [data, setData] = useState([]);
   const [period, setPeriod] = useState("day");
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchMovies = async () => {
-      try {
-        const data = await fetchTrendingMoviesWithRuntime(period);
-        setData(data);
-      } catch (err) {
-        console.error("fetchMovies failed:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMovies();
-  }, [period]);
+  const { data, loading } = useTrendingMoviesWithRuntime(period);
 
   if (loading) return <SwiperSkeleton count={5} />;
 

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -3,8 +3,7 @@ import { Navigation, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 
-import { useEffect, useState } from "react";
-import { fetchUpcomingMovies } from "../../../api/tmdb";
+import { useUpcomingMovies } from "../../../hooks/useUpcomingMovies";
 import { getDDay } from "../../../utils/format";
 import "../common/Section.css";
 import SectionHeader from "../common/SectionHeader";
@@ -15,23 +14,7 @@ import release from "../../../assets/icons/release.svg";
 import popularity from "../../../assets/icons/popularity.svg";
 
 const UpcomingSection = () => {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchMovies = async () => {
-      try {
-        const data = await fetchUpcomingMovies();
-        setData(data);
-      } catch (err) {
-        console.error("fetchMovies failed:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMovies();
-  }, []);
-
+  const { data, loading } = useUpcomingMovies();
   if (loading) return <SwiperSkeleton count={5} />;
 
   return (

--- a/src/hooks/useGenres.js
+++ b/src/hooks/useGenres.js
@@ -5,25 +5,19 @@ export function useGenres() {
   const [genreMap, setGenreMap] = useState(null);
 
   useEffect(() => {
-    const controller = new AbortController(); // fetch를 제어할 컨트롤러 생성
-    const signal = controller.signal; // signal을 fetch에 전달할 준비
+    let ignore = false;
 
     (async () => {
       try {
-        const data = await fetchGenreMap({ signal });
-        setGenreMap(data);
+        const data = await fetchGenreMap();
+        if (!ignore) setGenreMap(data);
       } catch (err) {
-        // AbortError인 경우는 무시
-        if (err.name === "AbortError") return;
-        else {
-          console.error("Failed to fetch Movie Genres", err);
-        }
+        console.error("Failed to fetch Movie Genres", err);
       }
     })();
 
-    // 컴포넌트가 사라질 때 (fetch 취소)
     return () => {
-      controller.abort();
+      ignore = true;
     };
   }, []);
 

--- a/src/hooks/useHeroMovies.js
+++ b/src/hooks/useHeroMovies.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { fetchHeroMovies } from "../api/tmdb";
+
+export function useHeroMovies() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    (async () => {
+      try {
+        const res = await fetchHeroMovies();
+        if (!ignore) setData(res);
+      } catch (err) {
+        console.error("fetchHeroMovies failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return { data, loading };
+}

--- a/src/hooks/useNowPlayingWithTrailers.js
+++ b/src/hooks/useNowPlayingWithTrailers.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { fetchNowPlayingPagesWithTrailers } from "../api/tmdb";
+
+export function useNowPlayingPagesWithTrailers() {
+  const [data, setData] = useState({ page1: [], page2: [] });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    (async () => {
+      try {
+        const res = await fetchNowPlayingPagesWithTrailers();
+        if (!ignore) setData(res); // { page1, page2 }
+      } catch (err) {
+        console.error("fetchNowPlayingPagesWithTrailers failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return { data, loading };
+}

--- a/src/hooks/useTrendingMoviesWithRuntime.js
+++ b/src/hooks/useTrendingMoviesWithRuntime.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { fetchTrendingMoviesWithRuntime } from "../api/tmdb";
+
+export function useTrendingMoviesWithRuntime(period = "day") {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetchTrendingMoviesWithRuntime(period);
+        if (!ignore) setData(res);
+      } catch (err) {
+        console.error("fetchTrendingMoviesWithRuntime failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [period]);
+
+  return { data, loading };
+}

--- a/src/hooks/useUpcomingMovies.js
+++ b/src/hooks/useUpcomingMovies.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { fetchUpcomingMovies } from "../api/tmdb";
+
+export function useUpcomingMovies() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    (async () => {
+      try {
+        const res = await fetchUpcomingMovies();
+        if (!ignore) setData(res);
+      } catch (err) {
+        console.error("fetchUpcomingMovies failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return { data, loading };
+}


### PR DESCRIPTION
### ✅ 변경사항  

#### 1. HeroSection  
- **`useHeroMovies()` 훅 구현 및 적용**  
  - 단순 fetch + 상태 관리 로직을 훅으로 이동  

#### 2. NowPlayingSection  
- **`useNowPlayingPagesWithTrailers()` 훅 구현 및 적용**  
  - 단순 fetch + 상태 관리 로직을 훅으로 이동  

#### 3. TrendingSection  
- **`useTrendingMoviesWithRuntime()` 훅 구현 및 적용**  
 - 단순 fetch + 상태 관리 로직을 훅으로 이동  

#### 4. UpcomingSection  
- **`useUpcomingMovies()` 훅 구현 및 적용**  
  - 단순 fetch + 상태 관리 로직을 훅으로 이동  


#### 5. useGenres  
- **AbortController 제거 및 ignore 플래그 방식으로 변경**  
  - 언마운트 시 `AbortError` 로그 발생 방지를 위해 `ignore` 플래그 사용  

---

### ⭐ 이후 수정 사항
- TMDB API 파일 분리 예정