### PR TITLE
[Feat] 디테일 페이지 이동 구현 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,10 +5,12 @@ import Home from "./pages/Home";
 import SearchResult from "./pages/SearchResult";
 import "./App.css";
 import MovieDetail from "./pages/MovieDetail";
+import ScrollToTop from "./components/sections/common/ScrollToTop";
 
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <div className="App">
         <Header />
         <main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Header from "./components/layout/Header";
 import Home from "./pages/Home";
 import SearchResult from "./pages/SearchResult";
 import "./App.css";
+import MovieDetail from "./pages/MovieDetail";
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/search" element={<SearchResult />} />
+            <Route path="/movie/:id" element={<MovieDetail />} />
           </Routes>
         </main>
         <Footer />

--- a/src/assets/trailer-default.svg
+++ b/src/assets/trailer-default.svg
@@ -10,68 +10,81 @@
   <title id="title">Trailer Unavailable Placeholder</title>
   <desc id="desc">A 16:9 video placeholder with a play icon and timeline bar</desc>
 
-  <!-- ====== Theming (override via CSS-in-SVG or data-uri) ====== -->
   <style>
-    :root{
+    :root {
       --bg-start:#2d2d2d;
       --bg-end:#0f0f0f;
       --frame:#ffffff22;
       --accent:#1ed5aa;
       --text:#e8eefc;
-      --subtext:#b9c6e4;
-      --glow: #5d6c7079;
+      --glow:#5d6c7079;
     }
   </style>
 
-  <!-- Background gradient -->
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%"  stop-color="var(--bg-start)"/>
-      <stop offset="100%" stop-color="var(--bg-end)"/>
+      <stop offset="0%" stop-color="var(--bg-start)" />
+      <stop offset="100%" stop-color="var(--bg-end)" />
     </linearGradient>
 
-    <!-- soft vignette -->
     <radialGradient id="v" cx="50%" cy="45%" r="70%">
-      <stop offset="0%" stop-color="#00000000"/>
-      <stop offset="100%" stop-color="#00000066"/>
+      <stop offset="0%" stop-color="#00000000" />
+      <stop offset="100%" stop-color="#00000066" />
     </radialGradient>
 
-    <!-- drop shadow for play button -->
     <filter id="softShadow" x="-50%" y="-50%" width="200%" height="200%">
-      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#00000066"/>
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#00000066" />
     </filter>
   </defs>
 
-  <rect x="0" y="0" width="1280" height="720" fill="url(#g)"/>
-  <rect x="0" y="0" width="1280" height="720" fill="url(#v)"/>
+  <!-- ✅ 바깥 전체 영역은 완전 검정 -->
+  <rect x="0" y="0" width="1280" height="720" fill="#000000" />
 
-  <!-- Safe area video frame (16:9) -->
+  <!-- ✅ 영상(그라디언트)은 가운데 프레임 영역만 -->
   <g transform="translate(40,40)">
-    <rect x="0" y="0" width="1200" height="640" rx="18" ry="18"
-          fill="#ffffff08" stroke="var(--frame)" stroke-width="2"/>
-    <!-- subtle inner border -->
-    <rect x="6" y="6" width="1188" height="628" rx="14" ry="14"
-          fill="none" stroke="#ffffff12" stroke-width="1"/>
+    <rect x="0" y="0" width="1200" height="640" rx="18" ry="18" fill="url(#g)" />
+    <rect x="0" y="0" width="1200" height="640" rx="18" ry="18" fill="url(#v)" />
   </g>
 
-  <!-- Play button in center -->
+  <!-- Frame outline -->
+  <g transform="translate(40,40)">
+    <rect
+      x="0"
+      y="0"
+      width="1200"
+      height="640"
+      rx="18"
+      ry="18"
+      fill="none"
+      stroke="var(--frame)"
+      stroke-width="2"
+    />
+    <rect
+      x="6"
+      y="6"
+      width="1188"
+      height="628"
+      rx="14"
+      ry="14"
+      fill="none"
+      stroke="#ffffff12"
+      stroke-width="1"
+    />
+  </g>
+
+  <!-- Play button -->
   <g transform="translate(640,360)" filter="url(#softShadow)">
-    <circle r="70" fill="var(--glow)"/>
-    <circle r="60" fill="#ffffff20" stroke="var(--accent)" stroke-width="2"/>
-    <polygon points="-18,-28 32,0 -18,28"
-             fill="var(--accent)"/>
+    <circle r="70" fill="var(--glow)" />
+    <circle r="60" fill="#ffffff20" stroke="var(--accent)" stroke-width="2" />
+    <polygon points="-18,-28 32,0 -18,28" fill="var(--accent)" />
   </g>
 
-  <!-- Timeline (video UI) -->
+  <!-- Timeline -->
   <g transform="translate(120, 600)">
-    <!-- total track -->
-    <rect x="0" y="0" width="1040" height="6" rx="3" fill="#ffffff26"/>
-    <!-- buffered -->
-    <rect x="0" y="0" width="620" height="6" rx="3" fill="#ffffff4a"/>
-    <!-- played -->
-    <rect x="0" y="0" width="380" height="6" rx="3" fill="var(--accent)"/>
-    <!-- knob -->
-    <circle cx="380" cy="3" r="8" fill="#fff" stroke="var(--accent)" stroke-width="2"/>
+    <rect x="0" y="0" width="1040" height="6" rx="3" fill="#ffffff26" />
+    <rect x="0" y="0" width="620" height="6" rx="3" fill="#ffffff4a" />
+    <rect x="0" y="0" width="380" height="6" rx="3" fill="var(--accent)" />
+    <circle cx="380" cy="3" r="8" fill="#fff" stroke="var(--accent)" stroke-width="2" />
   </g>
 
   <!-- Caption -->
@@ -81,17 +94,15 @@
     </text>
   </g>
 
-  <!-- corner film hint (subtle, to imply "video" not camera) -->
+  <!-- Film corners -->
   <g opacity="0.18">
-    <rect x="56" y="56" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="100" y="56" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="1088" y="56" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="1132" y="56" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="56" y="656" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="100" y="656" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="1088" y="656" width="36" height="8" rx="2" fill="#fff"/>
-    <rect x="1132" y="656" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="56" y="56" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="100" y="56" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="1088" y="56" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="1132" y="56" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="56" y="656" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="100" y="656" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="1088" y="656" width="36" height="8" rx="2" fill="#fff" />
+    <rect x="1132" y="656" width="36" height="8" rx="2" fill="#fff" />
   </g>
 </svg>
-
-

--- a/src/assets/trailer-default.svg
+++ b/src/assets/trailer-default.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  width="1280"
+  height="720"
+  viewBox="0 0 1280 720"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">Trailer Unavailable Placeholder</title>
+  <desc id="desc">A 16:9 video placeholder with a play icon and timeline bar</desc>
+
+  <!-- ====== Theming (override via CSS-in-SVG or data-uri) ====== -->
+  <style>
+    :root{
+      --bg-start:#2d2d2d;
+      --bg-end:#0f0f0f;
+      --frame:#ffffff22;
+      --accent:#1ed5aa;
+      --text:#e8eefc;
+      --subtext:#b9c6e4;
+      --glow: #5d6c7079;
+    }
+  </style>
+
+  <!-- Background gradient -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"  stop-color="var(--bg-start)"/>
+      <stop offset="100%" stop-color="var(--bg-end)"/>
+    </linearGradient>
+
+    <!-- soft vignette -->
+    <radialGradient id="v" cx="50%" cy="45%" r="70%">
+      <stop offset="0%" stop-color="#00000000"/>
+      <stop offset="100%" stop-color="#00000066"/>
+    </radialGradient>
+
+    <!-- drop shadow for play button -->
+    <filter id="softShadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#00000066"/>
+    </filter>
+  </defs>
+
+  <rect x="0" y="0" width="1280" height="720" fill="url(#g)"/>
+  <rect x="0" y="0" width="1280" height="720" fill="url(#v)"/>
+
+  <!-- Safe area video frame (16:9) -->
+  <g transform="translate(40,40)">
+    <rect x="0" y="0" width="1200" height="640" rx="18" ry="18"
+          fill="#ffffff08" stroke="var(--frame)" stroke-width="2"/>
+    <!-- subtle inner border -->
+    <rect x="6" y="6" width="1188" height="628" rx="14" ry="14"
+          fill="none" stroke="#ffffff12" stroke-width="1"/>
+  </g>
+
+  <!-- Play button in center -->
+  <g transform="translate(640,360)" filter="url(#softShadow)">
+    <circle r="70" fill="var(--glow)"/>
+    <circle r="60" fill="#ffffff20" stroke="var(--accent)" stroke-width="2"/>
+    <polygon points="-18,-28 32,0 -18,28"
+             fill="var(--accent)"/>
+  </g>
+
+  <!-- Timeline (video UI) -->
+  <g transform="translate(120, 600)">
+    <!-- total track -->
+    <rect x="0" y="0" width="1040" height="6" rx="3" fill="#ffffff26"/>
+    <!-- buffered -->
+    <rect x="0" y="0" width="620" height="6" rx="3" fill="#ffffff4a"/>
+    <!-- played -->
+    <rect x="0" y="0" width="380" height="6" rx="3" fill="var(--accent)"/>
+    <!-- knob -->
+    <circle cx="380" cy="3" r="8" fill="#fff" stroke="var(--accent)" stroke-width="2"/>
+  </g>
+
+  <!-- Caption -->
+  <g text-anchor="middle" font-family="system-ui, -apple-system, Segoe UI, Roboto, Noto Sans KR, Arial">
+    <text x="640" y="500" font-size="38" fill="var(--text)" opacity="0.95" letter-spacing="0.3px">
+      트레일러가 준비되지 않은 영화입니다.
+    </text>
+  </g>
+
+  <!-- corner film hint (subtle, to imply "video" not camera) -->
+  <g opacity="0.18">
+    <rect x="56" y="56" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="100" y="56" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="1088" y="56" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="1132" y="56" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="56" y="656" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="100" y="656" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="1088" y="656" width="36" height="8" rx="2" fill="#fff"/>
+    <rect x="1132" y="656" width="36" height="8" rx="2" fill="#fff"/>
+  </g>
+</svg>
+
+

--- a/src/components/sections/HeroSection/HeroSection.jsx
+++ b/src/components/sections/HeroSection/HeroSection.jsx
@@ -20,10 +20,6 @@ const HeroSection = () => {
 
   async function handleTrailerOpen(movie) {
     const url = await fetchTrailers(movie.id);
-    if (!url) {
-      alert("트레일러가 준비되지 않은 영화입니다.");
-      return;
-    }
     setTrailer({ url, id: movie.id });
     swiperRef.current?.autoplay?.stop?.();
   }
@@ -71,7 +67,7 @@ const HeroSection = () => {
                   <span>TRAILER</span>
                 </button>
               </div>
-              {Boolean(trailer.url) && (
+              {trailer.id !== null && (
                 <TrailerModal
                   id={trailer.id}
                   trailer={trailer.url}

--- a/src/components/sections/HeroSection/HeroSection.jsx
+++ b/src/components/sections/HeroSection/HeroSection.jsx
@@ -15,7 +15,7 @@ import playIcon from "../../../assets/icons/play.svg";
 const HeroSection = () => {
   const { data, loading } = useHeroMovies();
   const genreMap = useGenres(null);
-  const [trailer, setTrailer] = useState("");
+  const [trailer, setTrailer] = useState({ url: "", id: null });
   const swiperRef = useRef(null);
 
   async function handleTrailerOpen(movie) {
@@ -24,12 +24,12 @@ const HeroSection = () => {
       alert("트레일러가 준비되지 않은 영화입니다.");
       return;
     }
-    setTrailer(url || "");
+    setTrailer({ url, id: movie.id });
     swiperRef.current?.autoplay?.stop?.();
   }
 
   function handleTrailerClose() {
-    setTrailer("");
+    setTrailer({ url: "", id: null });
     swiperRef.current?.autoplay?.start?.();
   }
 
@@ -71,9 +71,10 @@ const HeroSection = () => {
                   <span>TRAILER</span>
                 </button>
               </div>
-              {trailer && (
+              {Boolean(trailer.url) && (
                 <TrailerModal
-                  trailer={trailer}
+                  id={trailer.id}
+                  trailer={trailer.url}
                   onClose={handleTrailerClose}
                   display="right"
                 />

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
@@ -10,22 +10,25 @@ import TrailerModal from "./TrailerModal";
 const NowPlayingSection = () => {
   const { data: rows, loading } = useNowPlayingPagesWithTrailers();
   const [animate, setAnimate] = useState(true);
-  const [trailer, setTrailer] = useState(""); // iframe src
+  const [trailer, setTrailer] = useState({ url: "", id: null }); // iframe src
 
   const onStop = () => {
-    if (!trailer) setAnimate(false);
+    if (!trailer.url) setAnimate(false);
   };
   const onRun = () => {
-    if (!trailer) setAnimate(true);
+    if (!trailer.url) setAnimate(true);
   };
 
   function handleTrailerOpen(movie) {
     setAnimate(false);
-    setTrailer(movie.trailerUrl || "");
+    setTrailer({
+      url: movie.trailerUrl || "",
+      id: movie.id,
+    });
   }
 
   function handleTrailerClose() {
-    setTrailer("");
+    setTrailer({ url: "", id: null });
     setAnimate(true);
   }
 
@@ -39,9 +42,10 @@ const NowPlayingSection = () => {
         hasNav={false}
       />
 
-      {trailer && (
+      {Boolean(trailer.url) && (
         <TrailerModal
-          trailer={trailer}
+          id={trailer.id}
+          trailer={trailer.url}
           onClose={handleTrailerClose}
           display="center"
         />

--- a/src/components/sections/NowPlayingSection/TrailerModal.css
+++ b/src/components/sections/NowPlayingSection/TrailerModal.css
@@ -1,4 +1,5 @@
 .trailer-modal {
+  display: relative;
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.7);
@@ -14,6 +15,7 @@
 .trailer-modal--right {
   justify-content: flex-end;
   padding-right: 30px;
+  padding-top: 100px;
 }
 
 .trailer-frame-wrap {
@@ -28,16 +30,42 @@
   border: 0;
 }
 
-.trailer-close {
+.trailer-toolbar {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  font-size: 22px;
+  top: -50px;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 15px;
+  padding: 10px;
+  background: black;
+}
+
+.trailer-detail,
+.trailer-close {
   line-height: 1;
-  background: rgba(0, 0, 0, 0.5);
-  color: white;
-  border: 0;
+  border: none;
   border-radius: 8px;
-  padding: 6px 10px;
+  color: #fff;
+  font-weight: 500;
   cursor: pointer;
+}
+
+.trailer-detail {
+  background: var(--gradient-primary-soft);
+  padding: 9px 14px;
+}
+.trailer-detail:hover {
+  background: var(--gradient-primary);
+}
+
+.trailer-close {
+  background: var(--bg-pill);
+  backdrop-filter: blur(4px);
+  color: #fff;
+  font-size: 22px;
+  padding: 6px 10px;
+}
+.trailer-close:hover {
+  background: var(--color-gray-200);
 }

--- a/src/components/sections/NowPlayingSection/TrailerModal.jsx
+++ b/src/components/sections/NowPlayingSection/TrailerModal.jsx
@@ -20,12 +20,14 @@ export default function TrailerModal({ id, trailer, onClose, display }) {
             className="trailer-frame"
           />
         )}
-        <Link to={`/movie/${id}`}>
-          <button className="trailer-detail">View Details</button>
-        </Link>
-        <button className="trailer-close" onClick={onClose}>
-          ✕
-        </button>
+        <div className="trailer-toolbar">
+          <Link to={`/movie/${id}`}>
+            <button className="trailer-detail">View Details</button>
+          </Link>
+          <button className="trailer-close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/sections/NowPlayingSection/TrailerModal.jsx
+++ b/src/components/sections/NowPlayingSection/TrailerModal.jsx
@@ -1,18 +1,27 @@
 import { Link } from "react-router-dom";
 import "./TrailerModal.css";
+import noTrailer from "../../../assets/trailer-default.svg";
 
 export default function TrailerModal({ id, trailer, onClose, display }) {
   return (
     <div className={`trailer-modal trailer-modal--${display}`}>
       <div className="trailer-frame-wrap">
-        <iframe
-          className="trailer-iframe"
-          src={trailer}
-          title="Trailer"
-          allowFullScreen
-        />
-        <Link to={`/movie/${id}`} className="trailer-detail">
-          상세보기
+        {trailer ? (
+          <iframe
+            className="trailer-iframe"
+            src={trailer}
+            title="Trailer"
+            allowFullScreen
+          />
+        ) : (
+          <img
+            src={noTrailer}
+            alt="트레일러 영상 대체 이미지"
+            className="trailer-frame"
+          />
+        )}
+        <Link to={`/movie/${id}`}>
+          <button className="trailer-detail">View Details</button>
         </Link>
         <button className="trailer-close" onClick={onClose}>
           ✕

--- a/src/components/sections/NowPlayingSection/TrailerModal.jsx
+++ b/src/components/sections/NowPlayingSection/TrailerModal.jsx
@@ -1,6 +1,7 @@
+import { Link } from "react-router-dom";
 import "./TrailerModal.css";
 
-export default function TrailerModal({ trailer, onClose, display }) {
+export default function TrailerModal({ id, trailer, onClose, display }) {
   return (
     <div className={`trailer-modal trailer-modal--${display}`}>
       <div className="trailer-frame-wrap">
@@ -10,6 +11,9 @@ export default function TrailerModal({ trailer, onClose, display }) {
           title="Trailer"
           allowFullScreen
         />
+        <Link to={`/movie/${id}`} className="trailer-detail">
+          상세보기
+        </Link>
         <button className="trailer-close" onClick={onClose}>
           ✕
         </button>

--- a/src/components/sections/SearchSection/SearchSection.jsx
+++ b/src/components/sections/SearchSection/SearchSection.jsx
@@ -69,6 +69,7 @@ const SearchSection = () => {
             {sortedResults.map((movie) => (
               <SectionCard
                 key={movie.id}
+                id={movie.id}
                 posterPath={movie.poster_path}
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}

--- a/src/components/sections/SearchSection/SearchSection.jsx
+++ b/src/components/sections/SearchSection/SearchSection.jsx
@@ -24,7 +24,6 @@ const SearchSection = () => {
     next.set("q", query);
     next.set("page", String(nextPage));
     setParams(next);
-    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const hasResults = !loading && !error && results.length > 0;

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -63,6 +63,7 @@ const TrendingSection = () => {
           {data.map((movie) => (
             <SwiperSlide key={movie.id}>
               <SectionCard
+                id={movie.id}
                 posterPath={movie.poster_path}
                 title={movie.title}
                 meta={[

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -44,6 +44,7 @@ const UpcomingSection = () => {
           {data.map((movie) => (
             <SwiperSlide key={movie.id}>
               <SectionCard
+                id={movie.id}
                 posterPath={movie.poster_path}
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}

--- a/src/components/sections/common/ScrollToTop.jsx
+++ b/src/components/sections/common/ScrollToTop.jsx
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname, search } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname, search]);
+  return null;
+}

--- a/src/components/sections/common/SectionCard.jsx
+++ b/src/components/sections/common/SectionCard.jsx
@@ -1,29 +1,32 @@
+import { Link } from "react-router-dom";
 import noPoster from "../../../assets/poster-default.svg";
 import "./Section.css";
 
 const IMG = (p) => (p ? `https://image.tmdb.org/t/p/original/${p}` : noPoster);
 
-const SectionCard = ({ posterPath, title, badge, meta = [] }) => {
+const SectionCard = ({ id, posterPath, title, badge, meta = [] }) => {
   return (
-    <div className="card">
-      <div className="card-poster">
-        <img src={IMG(posterPath)} alt={title} />
-        {badge && <div className="card-badge">{badge}</div>}
-      </div>
+    <Link to={`/movie/${id}`}>
+      <div className="card">
+        <div className="card-poster">
+          <img src={IMG(posterPath)} alt={title} />
+          {badge && <div className="card-badge">{badge}</div>}
+        </div>
 
-      <div className="card-content">
-        <h3 className="card-title">{title}</h3>
+        <div className="card-content">
+          <h3 className="card-title">{title}</h3>
 
-        <div className="card-meta">
-          {meta.map(({ icon, text, alt }, i) => (
-            <div className="meta-pill" key={i}>
-              <img src={icon} alt={alt || "meta"} />
-              <span>{text}</span>
-            </div>
-          ))}
+          <div className="card-meta">
+            {meta.map(({ icon, text, alt }, i) => (
+              <div className="meta-pill" key={i}>
+                <img src={icon} alt={alt || "meta"} />
+                <span>{text}</span>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,9 +1,13 @@
 import React from "react";
+import { useParams } from "react-router-dom";
 
 const MovieDetail = () => {
+  const { id } = useParams();
+
   return (
     <div>
       <h1>Detail 페이지</h1>
+      <p>id: {id}</p>
     </div>
   );
 };

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const MovieDetail = () => {
+  return (
+    <div>
+      <h1>Detail 페이지</h1>
+    </div>
+  );
+};
+
+export default MovieDetail;


### PR DESCRIPTION
### 👀 구현 화면
<img width="937" height="575" alt="image" src="https://github.com/user-attachments/assets/3fd46ad9-b624-4e77-9606-e97089e94f06" />

---

### ✅ 변경사항
- **디테일 페이지 라우팅 추가**
  - `/movie/:id` 경로를 라우터에 등록
  - `useParams`로 id를 받아 표시 (이동 경로 확인용 텍스트 출력)

- **영화 카드 클릭 시 상세 페이지 이동**
  - `Link` 컴포넌트를 적용해 `/movie/:id`로 이동하도록 구현

- **TrailerModal 기능 개선**
  - “View Details” 이동 버튼 추가 및 `/movie/:id` 경로로 연결
  - **HeroSection**, **NowPlayingSection**에서 트레일러 데이터를 불러올 때  
    **트레일러의 `url`뿐만 아니라 `id`도 함께 fetch**하도록 수정  
  - 트레일러 미존재 시 디폴트 이미지 적용

- **ScrollToTop 컴포넌트 추가**
  - 라우팅 시 자동으로 스크롤이 상단으로 이동하도록 처리

- **트레일러 모달 스타일링**
  - 레이아웃, 버튼, 텍스트 등 스타일 개선

