### PR TITLE
[Feat] DetailRecommended, DetailCollection 섹션 구현 완료

### DIFF
--- a/src/api/movies.js
+++ b/src/api/movies.js
@@ -35,6 +35,11 @@ export async function fetchMovieDetailFull(id) {
   });
 }
 
+// Movie Collection
+export async function fetchCollection(collectionId) {
+  return get(`/collection/${collectionId}`);
+}
+
 // Trending with runtime
 export async function fetchTrendingMoviesWithRuntime(period = "day") {
   const list = await fetchTrendingMovies(period);

--- a/src/components/sections/DetailSection/DetailRecommended/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRecommended/DetailRecommended.jsx
@@ -3,35 +3,46 @@ import { Navigation, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 
-import { useUpcomingMovies } from "@hooks/useUpcomingMovies";
-import { getDDay } from "@utils/format";
-import "@components/sections/common/Section.css";
 import SectionHeader from "@components/sections/common/SectionHeader";
 import SectionCard from "@components/sections/common/SectionCard";
+import { useRecommendationMovies } from "@hooks/useRecommendationMovies";
+import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
-
 import release from "@assets/icons/release.svg";
-import popularity from "@assets/icons/popularity.svg";
+import vote from "@assets/icons/vote.svg";
 
-const UpcomingSection = () => {
-  const { data, loading } = useUpcomingMovies();
+export default function DetailRecommended({ id }) {
+  const { data, loading } = useRecommendationMovies(id);
+
   if (loading) return <SwiperSkeleton count={5} />;
 
+  if (!data.length) {
+    return (
+      <section className="detail-recommended section">
+        <SectionHeader
+          title="Recommended Movies"
+          desc="이 영화와 비슷한 작품"
+        />
+        <p className="empty">표시할 항목이 없습니다.</p>
+      </section>
+    );
+  }
+
   return (
-    <section className="section">
+    <section className="detail-recommended section">
       <SectionHeader
-        title="Upcoming Movies"
-        desc="개봉을 앞둔 기대작들"
+        title="Recommended Movies"
+        desc="이 영화와 비슷한 작품"
         hasNav={true}
-        navId="upcoming"
+        navId="recommended"
       />
 
       <div className="section-swiper">
         <Swiper
           modules={[Navigation, A11y]}
           navigation={{
-            prevEl: '.section-prev[data-nav="upcoming"]',
-            nextEl: '.section-next[data-nav="upcoming"]',
+            prevEl: '.section-prev[data-nav="recommended"]',
+            nextEl: '.section-next[data-nav="recommended"]',
           }}
           spaceBetween={20}
           a11y={{ enabled: true }}
@@ -55,9 +66,9 @@ const UpcomingSection = () => {
                 meta={[
                   { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: popularity,
-                    text: Math.round(movie.popularity),
-                    alt: "인기도",
+                    icon: vote,
+                    text: (movie.vote_average ?? 0).toFixed(1),
+                    alt: "평점",
                   },
                 ]}
               />
@@ -67,6 +78,4 @@ const UpcomingSection = () => {
       </div>
     </section>
   );
-};
-
-export default UpcomingSection;
+}

--- a/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
@@ -5,23 +5,27 @@ import "swiper/css/navigation";
 
 import SectionHeader from "@components/sections/common/SectionHeader";
 import SectionCard from "@components/sections/common/SectionCard";
-import { useRecommendationMovies } from "@hooks/useRecommendationMovies";
+import { useCollectionMovies } from "@/hooks/useCollectionMovies";
 import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 import release from "@assets/icons/release.svg";
 import vote from "@assets/icons/vote.svg";
 
-export default function DetailRecommended({ id }) {
-  const { data, loading } = useRecommendationMovies(id);
+const DetailCollection = ({ id }) => {
+  const { collection, parts, loading } = useCollectionMovies(id);
 
   if (loading) return <SwiperSkeleton count={5} />;
 
-  if (!data.length) {
+  if (!parts.length) {
     return (
-      <section className="detail-recommended section">
+      <section className="detail-related section">
         <SectionHeader
-          title="Recommended Movies"
-          desc="이 영화와 비슷한 작품"
+          title="Collection Movies"
+          desc={
+            collection?.name
+              ? `"${collection.name}" 에 포함된 영화들`
+              : "같은 컬렉션에 포함된 영화들"
+          }
         />
         <p className="empty">표시할 항목이 없습니다.</p>
       </section>
@@ -29,20 +33,24 @@ export default function DetailRecommended({ id }) {
   }
 
   return (
-    <section className="detail-recommended section">
+    <section className="detail-related section">
       <SectionHeader
-        title="Recommended Movies"
-        desc="이 영화와 비슷한 작품"
+        title="Collection Movies"
+        desc={
+          collection?.name
+            ? `"${collection.name}" 에 포함된 영화들`
+            : "컬렉션에 포함된 영화들"
+        }
         hasNav={true}
-        navId="recommended"
+        navId="collection"
       />
 
       <div className="section-swiper">
         <Swiper
           modules={[Navigation, A11y]}
           navigation={{
-            prevEl: '.section-prev[data-nav="recommended"]',
-            nextEl: '.section-next[data-nav="recommended"]',
+            prevEl: '.section-prev[data-nav="collection"]',
+            nextEl: '.section-next[data-nav="collection"]',
           }}
           spaceBetween={20}
           a11y={{ enabled: true }}
@@ -56,7 +64,7 @@ export default function DetailRecommended({ id }) {
           }}
           rewind={true}
         >
-          {data.map((movie) => (
+          {parts.map((movie) => (
             <SwiperSlide key={movie.id}>
               <SectionCard
                 id={movie.id}
@@ -78,4 +86,6 @@ export default function DetailRecommended({ id }) {
       </div>
     </section>
   );
-}
+};
+
+export default DetailCollection;

--- a/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
@@ -1,0 +1,81 @@
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, A11y } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/navigation";
+
+import SectionHeader from "@components/sections/common/SectionHeader";
+import SectionCard from "@components/sections/common/SectionCard";
+import { useRecommendationMovies } from "@hooks/useRecommendationMovies";
+import { getDDay } from "@utils/format";
+import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
+export default function DetailRecommended({ id }) {
+  const { data, loading } = useRecommendationMovies(id);
+
+  if (loading) return <SwiperSkeleton count={5} />;
+
+  if (!data.length) {
+    return (
+      <section className="detail-related section">
+        <SectionHeader
+          title="Recommended Movies"
+          desc="이 영화와 비슷한 작품"
+        />
+        <p className="empty">표시할 항목이 없습니다.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="detail-recommended section">
+      <SectionHeader
+        title="Recommended Movies"
+        desc="이 영화와 비슷한 작품"
+        hasNav={true}
+        navId="recommended"
+      />
+
+      <div className="section-swiper">
+        <Swiper
+          modules={[Navigation, A11y]}
+          navigation={{
+            prevEl: '.section-prev[data-nav="recommended"]',
+            nextEl: '.section-next[data-nav="recommended"]',
+          }}
+          spaceBetween={20}
+          a11y={{ enabled: true }}
+          slidesPerView={5}
+          slidesPerGroup={5}
+          breakpoints={{
+            320: { slidesPerView: 1, slidesPerGroup: 1 },
+            640: { slidesPerView: 2, slidesPerGroup: 2 },
+            1024: { slidesPerView: 4, slidesPerGroup: 4 },
+            1280: { slidesPerView: 5, slidesPerGroup: 5 },
+          }}
+          rewind={true}
+        >
+          {data.map((movie) => (
+            <SwiperSlide key={movie.id}>
+              <SectionCard
+                id={movie.id}
+                posterPath={movie.poster_path}
+                title={movie.title}
+                badge={movie.release_date ? getDDay(movie.release_date) : null}
+                meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
+                  {
+                    icon: vote,
+                    text: (movie.vote_average ?? 0).toFixed(1),
+                    alt: "평점",
+                  },
+                ]}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNowPlayingPagesWithTrailers } from "../../../hooks/useNowPlayingWithTrailers";
+import { useNowPlayingPagesWithTrailers } from "@hooks/useNowPlayingWithTrailers";
 
 import "./NowPlayingSection.css";
 import "@components/sections/common/Section.css";
@@ -40,7 +40,7 @@ const NowPlayingSection = () => {
   return (
     <section className="section">
       <SectionHeader
-        title="Now Playing"
+        title="Now Playing Movies"
         desc="극장에서 상영 중인 최신 영화들"
         hasNav={false}
       />

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -23,7 +23,7 @@ const TrendingSection = () => {
   return (
     <section className="section">
       <SectionHeader
-        title="Trending"
+        title="Trending Movies"
         desc="전 세계에서 가장 주목받는 영화들"
         hasNav={true}
         navId="trending"

--- a/src/hooks/useCollectionMovies.js
+++ b/src/hooks/useCollectionMovies.js
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { fetchMovieDetailFull, fetchCollection } from "@api/movies";
+
+export function useCollectionMovies(id) {
+  const [collection, setCollection] = useState(null); // 컬렉션 메타 (name, id 등)
+  const [parts, setParts] = useState([]); // 컬렉션에 포함된 영화들
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+
+    let ignore = false;
+
+    (async () => {
+      try {
+        const detail = await fetchMovieDetailFull(id);
+        if (ignore) return;
+
+        const col = detail?.belongs_to_collection;
+        if (!col?.id) {
+          if (!ignore) {
+            setCollection(null);
+            setParts([]);
+          }
+          return;
+        }
+
+        // parts 정렬/필터
+        const full = await fetchCollection(col.id);
+        if (ignore) return;
+
+        const sorted = (full?.parts ?? [])
+          .filter((m) => m && m.id && m.poster_path)
+          .filter((m) => !m.adult)
+          .filter((m) => String(m.id) !== String(id))
+          .sort((a, b) => {
+            const da = a.release_date || "9999-12-31";
+            const db = b.release_date || "9999-12-31";
+            return da.localeCompare(db); // 오름차순
+          });
+
+        setCollection({
+          id: full?.id ?? col.id,
+          name: full?.name ?? col.name,
+          poster_path: full?.poster_path ?? col.poster_path,
+          backdrop_path: full?.backdrop_path ?? col.backdrop_path,
+          partsCount: sorted.length,
+        });
+        setParts(sorted);
+      } catch (err) {
+        console.error("fetchCollectionMovies failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [id]);
+
+  return { collection, parts, loading };
+}

--- a/src/hooks/useRecommendationMovies.js
+++ b/src/hooks/useRecommendationMovies.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { fetchMovieDetailFull } from "@api/movies";
+
+export function useRecommendationMovies(id) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+
+    let ignore = false;
+
+    (async () => {
+      try {
+        const detail = await fetchMovieDetailFull(id);
+        if (ignore) return;
+
+        const results = (detail?.recommendations?.results ?? [])
+          .filter((m) => m && m.id && m.poster_path)
+          .filter((m) => !m.adult)
+          .filter((m) => String(m.id) !== String(id));
+
+        setData(results);
+      } catch (err) {
+        console.error("fetchRecommendationMovies failed:", err);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [id]);
+
+  return { data, loading };
+}

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -8,6 +8,7 @@ import TrailerModal from "@components/sections/common/TrailerModal";
 import DetailPeople from "@components/sections/DetailSection/DetailPeople/DetailPeople";
 import DetailMedia from "@components/sections/DetailSection/DetailMedia/DetailMedia";
 import DetailInfo from "@components/sections/DetailSection/DetailInfo/DetailInfo";
+import Recommendation from "@/components/sections/DetailSection/DetailRecommended/DetailRecommended";
 
 const MovieDetail = () => {
   const { id } = useParams();
@@ -60,6 +61,8 @@ const MovieDetail = () => {
       />
 
       <DetailInfo detail={detail} />
+
+      <Recommendation id={id} />
     </div>
   );
 };

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -8,7 +8,8 @@ import TrailerModal from "@components/sections/common/TrailerModal";
 import DetailPeople from "@components/sections/DetailSection/DetailPeople/DetailPeople";
 import DetailMedia from "@components/sections/DetailSection/DetailMedia/DetailMedia";
 import DetailInfo from "@components/sections/DetailSection/DetailInfo/DetailInfo";
-import Recommendation from "@/components/sections/DetailSection/DetailRecommended/DetailRecommended";
+import Recommendation from "@/components/sections/DetailSection/DetailRelated/DetailRecommended";
+import DetailCollection from "@/components/sections/DetailSection/DetailRelated/DetailCollection";
 
 const MovieDetail = () => {
   const { id } = useParams();
@@ -62,6 +63,7 @@ const MovieDetail = () => {
 
       <DetailInfo detail={detail} />
 
+      <DetailCollection id={id} />
       <Recommendation id={id} />
     </div>
   );


### PR DESCRIPTION
### ✅ 변경사항
- **DetailRecommended 섹션 구현**
  - 추천 영화(`recommendations.results`) 표시
  - `SectionHeader`, `SectionCard`, `SwiperSkeleton` 공용 컴포넌트 재사용

- **useRecommendationMovies 훅 구현**
  - `/movie/{id}?append_to_response=recommendations` 데이터 패칭
  - 포스터 없는 항목, 성인물, 자기 자신 필터링

- **DetailCollection 섹션 구현**
  - 컬렉션(`belongs_to_collection`) 확인 후 `/collection/{id}` 호출
  - `SectionHeader`, `SectionCard`, `SwiperSkeleton` 공용 컴포넌트 재사용

- **useCollectionMovies 훅 구현**
  - 컬렉션 메타(`name`, `poster_path`) + `parts` 데이터 분리 관리
  - `release_date` 기준 정렬 및 포스터, 성인물, 자기 자신 필터링
  - 정제된 `parts` 상태 반환 (`setParts(sorted)`)