### PR TITLE
[Feat] SideNav 생성 및 디테일 페이지 기능 개선

### DIFF
--- a/src/components/sections/DetailSection/DetailHero/DetailHero.css
+++ b/src/components/sections/DetailSection/DetailHero/DetailHero.css
@@ -31,12 +31,16 @@
   max-width: 1240px;
   margin: 0 auto;
   padding: 120px 20px 80px;
-  display: grid;
-  grid-template-columns: 280px 1fr;
+
+  display: flex;
+  align-items: flex-start;
   gap: 40px;
   z-index: var(--z-hero-content);
 }
 
+.detail-hero__poster {
+  flex: 0 0 280px;
+}
 .detail-hero__poster img {
   width: 100%;
   height: auto;
@@ -45,6 +49,8 @@
 }
 
 .detail-hero__content {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -132,4 +138,40 @@
   width: 22px;
   height: 22px;
   display: block;
+}
+
+.detail-hero__poster svg,
+.detail-hero__content svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.detail-hero__backdrop svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 768px) {
+  .detail-hero {
+    min-height: 480px;
+  }
+
+  .detail-hero__container {
+    flex-direction: column;
+    gap: 16px;
+    padding: 80px 16px 48px;
+  }
+
+  .detail-hero__poster {
+    align-self: center;
+    flex: 0 0 auto;
+    width: 55vw;
+    max-width: 260px;
+  }
+
+  .detail-hero__content {
+    width: 100%;
+  }
 }

--- a/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
+++ b/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
@@ -6,7 +6,6 @@ import quoteOpen from "@assets/icons/quote-open.png";
 import quoteClose from "@assets/icons/quote-close.png";
 import favOutline from "@assets/icons/fav-outline.svg";
 import favFilled from "@assets/icons/fav-filled.svg";
-import DetailHeroSkeleton from "@components/sections/skeleton/DetailHeroSkeleton";
 import "./DetailHero.css";
 
 const DetailHero = ({ detail, onPlayTrailer }) => {

--- a/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
+++ b/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
@@ -6,6 +6,7 @@ import quoteOpen from "@assets/icons/quote-open.png";
 import quoteClose from "@assets/icons/quote-close.png";
 import favOutline from "@assets/icons/fav-outline.svg";
 import favFilled from "@assets/icons/fav-filled.svg";
+import DetailHeroSkeleton from "@components/sections/skeleton/DetailHeroSkeleton";
 import "./DetailHero.css";
 
 const DetailHero = ({ detail, onPlayTrailer }) => {

--- a/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
+++ b/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
@@ -41,7 +41,7 @@ const extractKeywords = (detail) => {
   return Array.isArray(list) ? list : [];
 };
 
-const DetailInfo = ({ detail }) => {
+const DetailInfo = ({ anchorId, detail }) => {
   const originalTitle = detail?.original_title || "—";
   const productionCountries = detail?.production_countries || "—";
   const originalLanguage = detail?.original_language || null;
@@ -59,7 +59,7 @@ const DetailInfo = ({ detail }) => {
   const links = buildExternalLinks(detail?.external_ids, detail?.homepage);
 
   return (
-    <section className="detail-info section">
+    <section id={anchorId} className="detail-info section">
       <div className="info-grid">
         {/* 원제/원어 */}
         <div className="info-card">

--- a/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
+++ b/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { formatMoney, formatPercent, languageLabel } from "@utils/format";
 import "./DetailInfo.css";
+import DetailInfoSkeleton from "@components/sections/skeleton/DetailInfoSkeleton";
 
 const buildExternalLinks = (external_ids = {}, homepage) => {
   const items = [];

--- a/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
+++ b/src/components/sections/DetailSection/DetailInfo/DetailInfo.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { formatMoney, formatPercent, languageLabel } from "@utils/format";
 import "./DetailInfo.css";
-import DetailInfoSkeleton from "@components/sections/skeleton/DetailInfoSkeleton";
 
 const buildExternalLinks = (external_ids = {}, homepage) => {
   const items = [];

--- a/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
+++ b/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
@@ -3,7 +3,6 @@ import arrowNext from "@assets/icons/arrow-icon-next.svg";
 import arrowPrev from "@assets/icons/arrow-icon-prev.svg";
 import MediaSwiper from "./MediaSwiper";
 import "./DetailMedia.css";
-import DetailSwiperSkeleton from "@components/sections/skeleton/DetailSwiperSkeleton";
 
 const TABS = [
   { key: "videos", label: "Video" },

--- a/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
+++ b/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
@@ -3,6 +3,7 @@ import arrowNext from "@assets/icons/arrow-icon-next.svg";
 import arrowPrev from "@assets/icons/arrow-icon-prev.svg";
 import MediaSwiper from "./MediaSwiper";
 import "./DetailMedia.css";
+import DetailSwiperSkeleton from "@components/sections/skeleton/DetailSwiperSkeleton";
 
 const TABS = [
   { key: "videos", label: "Video" },

--- a/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
+++ b/src/components/sections/DetailSection/DetailMedia/DetailMedia.jsx
@@ -10,7 +10,13 @@ const TABS = [
   { key: "posters", label: "Poster" },
 ];
 
-const DetailMedia = ({ videos = [], backdrops = [], posters = [], onPlay }) => {
+const DetailMedia = ({
+  anchorId,
+  videos = [],
+  backdrops = [],
+  posters = [],
+  onPlay,
+}) => {
   const [active, setActive] = useState("videos");
 
   const counts = {
@@ -20,7 +26,7 @@ const DetailMedia = ({ videos = [], backdrops = [], posters = [], onPlay }) => {
   };
 
   return (
-    <section className="detail-media section">
+    <section id={anchorId} className="detail-media section">
       <div className="detail-header">
         <div>
           {TABS.map(({ key, label }) => (

--- a/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
+++ b/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
@@ -3,7 +3,6 @@ import PeopleSwiper from "./PeopleSwiper";
 import "./DetailPeople.css";
 import arrowNext from "@assets/icons/arrow-icon-next.svg";
 import arrowPrev from "@assets/icons/arrow-icon-prev.svg";
-import DetailSwiperSkeleton from "@components/sections/skeleton/DetailSwiperSkeleton";
 
 const TABS = [
   { key: "cast", label: "Cast" },

--- a/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
+++ b/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
@@ -3,6 +3,7 @@ import PeopleSwiper from "./PeopleSwiper";
 import "./DetailPeople.css";
 import arrowNext from "@assets/icons/arrow-icon-next.svg";
 import arrowPrev from "@assets/icons/arrow-icon-prev.svg";
+import DetailSwiperSkeleton from "@components/sections/skeleton/DetailSwiperSkeleton";
 
 const TABS = [
   { key: "cast", label: "Cast" },

--- a/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
+++ b/src/components/sections/DetailSection/DetailPeople/DetailPeople.jsx
@@ -9,7 +9,7 @@ const TABS = [
   { key: "crew", label: "Crew" },
 ];
 
-export default function DetailPeople({ cast = [], crew = [] }) {
+export default function DetailPeople({ anchorId, cast = [], crew = [] }) {
   const [active, setActive] = useState("cast");
 
   const counts = {
@@ -18,7 +18,7 @@ export default function DetailPeople({ cast = [], crew = [] }) {
   };
 
   return (
-    <section className="detail-people section">
+    <section id={anchorId} className="detail-people section">
       <div className="detail-header">
         <div>
           {TABS.map(({ key, label }) => (

--- a/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
@@ -11,14 +11,14 @@ import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 import release from "@assets/icons/release.svg";
 import vote from "@assets/icons/vote.svg";
 
-const DetailCollection = ({ id }) => {
-  const { collection, parts, loading } = useCollectionMovies(id);
+const DetailCollection = ({ anchorId, movieId }) => {
+  const { collection, parts, loading } = useCollectionMovies(movieId);
 
   if (loading) return <SwiperSkeleton count={5} />;
 
   if (!parts.length) {
     return (
-      <section className="detail-related section">
+      <section id={anchorId} className="detail-related section">
         <SectionHeader
           title="Collection Movies"
           desc={
@@ -33,7 +33,7 @@ const DetailCollection = ({ id }) => {
   }
 
   return (
-    <section className="detail-related section">
+    <section id={anchorId} className="detail-related section">
       <SectionHeader
         title="Collection Movies"
         desc={

--- a/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
@@ -11,14 +11,14 @@ import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 import release from "@assets/icons/release.svg";
 import vote from "@assets/icons/vote.svg";
 
-export default function DetailRecommended({ id }) {
-  const { data, loading } = useRecommendationMovies(id);
+export default function DetailRecommended({ anchorId, movieId }) {
+  const { data, loading } = useRecommendationMovies(movieId);
 
   if (loading) return <SwiperSkeleton count={5} />;
 
   if (!data.length) {
     return (
-      <section className="detail-related section">
+      <section id={anchorId} className="detail-related section">
         <SectionHeader
           title="Recommended Movies"
           desc="이 영화와 비슷한 작품"

--- a/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
@@ -29,7 +29,7 @@ export default function DetailRecommended({ anchorId, movieId }) {
   }
 
   return (
-    <section className="detail-recommended section">
+    <section id={anchorId} className="detail-recommended section">
       <SectionHeader
         title="Recommended Movies"
         desc="이 영화와 비슷한 작품"

--- a/src/components/sections/HeroSection/HeroSection.css
+++ b/src/components/sections/HeroSection/HeroSection.css
@@ -66,6 +66,32 @@
   background: var(--bg-tag);
 }
 
+.hero-buttons {
+  display: flex;
+  gap: 15px;
+  font-weight: 700;
+}
+
+.hero-detail-btn {
+  border: 1px solid #fff;
+  border-radius: 50px;
+  width: 100px;
+  padding: 10px 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  background: transparent;
+  transition: all 0.3s ease;
+}
+
+.hero-detail-btn:hover {
+  background: var(--gradient-primary-soft);
+  border-color: transparent;
+}
+
 .hero-trailer-btn {
   background: var(--gradient-primary-soft);
   border-radius: 5px;
@@ -78,8 +104,4 @@
 }
 .hero-trailer-btn:hover {
   background: var(--gradient-primary);
-}
-
-.hero-trailer-btn span {
-  font-weight: 700;
 }

--- a/src/components/sections/HeroSection/HeroSection.jsx
+++ b/src/components/sections/HeroSection/HeroSection.jsx
@@ -3,6 +3,7 @@ import { Pagination, Autoplay, A11y } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/pagination";
 
+import { Link } from "react-router-dom";
 import { useState, useRef } from "react";
 import { useHeroMovies } from "@hooks/useHeroMovies";
 import { useGenres } from "@hooks/useGenres";
@@ -62,13 +63,18 @@ const HeroSection = () => {
                     </span>
                   ))}
                 </div>
-                <button
-                  className="hero-trailer-btn"
-                  onClick={() => handleTrailerOpen(movie)}
-                >
-                  <img src={playIcon} alt="트레일러 재생 버튼" />
-                  <span>TRAILER</span>
-                </button>
+                <div className="hero-buttons">
+                  <button
+                    className="hero-trailer-btn"
+                    onClick={() => handleTrailerOpen(movie)}
+                  >
+                    <img src={playIcon} alt="트레일러 재생 버튼" />
+                    <span>TRAILER</span>
+                  </button>
+                  <Link to={`/movie/${movie.id}`} className="hero-detail-btn">
+                    MORE INFO
+                  </Link>
+                </div>
               </div>
               {isOpen && (
                 <TrailerModal
@@ -76,6 +82,7 @@ const HeroSection = () => {
                   trailer={trailer.url}
                   onClose={handleTrailerClose}
                   display="right"
+                  detailBtn={false}
                 />
               )}
             </div>

--- a/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
+++ b/src/components/sections/NowPlayingSection/NowPlayingSection.jsx
@@ -7,7 +7,7 @@ import SectionHeader from "@components/sections/common/SectionHeader";
 import NowPlayingSkeleton from "@components/sections/skeleton/NowPlayingSkeleton";
 import TrailerModal from "@components/sections/common/TrailerModal";
 
-const NowPlayingSection = () => {
+const NowPlayingSection = ({ id }) => {
   const { data: rows, loading } = useNowPlayingPagesWithTrailers();
   const [animate, setAnimate] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
@@ -38,7 +38,7 @@ const NowPlayingSection = () => {
   if (loading) return <NowPlayingSkeleton />;
 
   return (
-    <section className="section">
+    <section id={id} className="section">
       <SectionHeader
         title="Now Playing Movies"
         desc="극장에서 상영 중인 최신 영화들"

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -14,14 +14,14 @@ import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 import vote from "@assets/icons/vote.svg";
 import runtime from "@assets/icons/runtime.svg";
 
-const TrendingSection = () => {
+const TrendingSection = ({ id }) => {
   const [period, setPeriod] = useState("day");
   const { data, loading } = useTrendingMoviesWithRuntime(period);
 
   if (loading) return <SwiperSkeleton count={5} />;
 
   return (
-    <section className="section">
+    <section id={id} className="section">
       <SectionHeader
         title="Trending Movies"
         desc="전 세계에서 가장 주목받는 영화들"

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -13,12 +13,12 @@ import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 import release from "@assets/icons/release.svg";
 import popularity from "@assets/icons/popularity.svg";
 
-const UpcomingSection = () => {
+const UpcomingSection = ({ id }) => {
   const { data, loading } = useUpcomingMovies();
   if (loading) return <SwiperSkeleton count={5} />;
 
   return (
-    <section className="section">
+    <section id={id} className="section">
       <SectionHeader
         title="Upcoming Movies"
         desc="개봉을 앞둔 기대작들"

--- a/src/components/sections/common/SideNav.css
+++ b/src/components/sections/common/SideNav.css
@@ -1,0 +1,48 @@
+.sidenav {
+  position: fixed;
+  top: 250px;
+  right: 20px;
+  width: 120px;
+  height: auto;
+  background: var(--bg);
+  border: 1px solid var(--color-primary);
+  border-radius: 12px;
+  padding: 12px 8px;
+  z-index: var(--z-sidenav);
+}
+
+.sidenav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sidenav-item:nth-child(1) {
+  border-bottom: 1px solid var(--color-primary);
+  padding-bottom: 15px;
+}
+
+.sidenav-btn {
+  width: 100%;
+  min-height: 20px;
+  color: #fff;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+.sidenav-btn:hover {
+  color: var(--color-primary);
+  text-decoration-line: underline;
+  text-decoration-color: var(--color-primary);
+}
+
+@media (max-width: 1024px) {
+  .sidenav {
+    display: none;
+  }
+}

--- a/src/components/sections/common/SideNav.css
+++ b/src/components/sections/common/SideNav.css
@@ -9,6 +9,9 @@
   border-radius: 12px;
   padding: 12px 8px;
   z-index: var(--z-sidenav);
+  opacity: 1;
+  transform: translateX(0);
+  transition: opacity 180ms ease, transform 220ms ease;
 }
 
 .sidenav-list {
@@ -27,9 +30,6 @@
   min-height: 20px;
   color: #fff;
   font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -41,8 +41,29 @@
   text-decoration-color: var(--color-primary);
 }
 
+.sidenav-toggle {
+  position: fixed;
+  top: 210px;
+  right: 20px;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-primary);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--color-primary);
+  display: flex;
+  place-items: center;
+  z-index: var(--z-sidenav);
+}
+.sidenav.sidenav-collapsed {
+  opacity: 0;
+  transform: translateX(12px);
+  pointer-events: none;
+}
+
 @media (max-width: 1024px) {
-  .sidenav {
+  .sidenav,
+  .sidenav-toggle {
     display: none;
   }
 }

--- a/src/components/sections/common/SideNav.css
+++ b/src/components/sections/common/SideNav.css
@@ -62,8 +62,35 @@
 }
 
 @media (max-width: 1024px) {
-  .sidenav,
   .sidenav-toggle {
     display: none;
+  }
+
+  .sidenav {
+    width: 50px;
+  }
+
+  .sidenav-label {
+    visibility: hidden;
+    position: relative;
+  }
+  .sidenav-btn {
+    position: relative;
+  }
+
+  .sidenav-btn::after {
+    content: attr(data-short);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+  .sidenav-btn:hover::after {
+    color: var(--color-primary);
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-primary);
   }
 }

--- a/src/components/sections/common/SideNav.jsx
+++ b/src/components/sections/common/SideNav.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SideNav = () => {
+  return <div></div>;
+};
+
+export default SideNav;

--- a/src/components/sections/common/SideNav.jsx
+++ b/src/components/sections/common/SideNav.jsx
@@ -43,6 +43,7 @@ export default function SideNav({ items = [], offsetTop = 80 }) {
                 <button
                   type="button"
                   className="sidenav-btn"
+                  data-short={it.short || it.label}
                   onClick={() => scrollToId(it.selector)}
                 >
                   <span className="sidenav-label">{it.label}</span>

--- a/src/components/sections/common/SideNav.jsx
+++ b/src/components/sections/common/SideNav.jsx
@@ -1,7 +1,39 @@
-import React from "react";
+import "./SideNav.css";
 
-const SideNav = () => {
-  return <div></div>;
-};
+export default function SideNav({ items = [], offsetTop = 80 }) {
+  const scrollToId = (id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const y = el.getBoundingClientRect().top + window.scrollY - offsetTop;
+    window.scrollTo({ top: y, behavior: "smooth" });
+  };
 
-export default SideNav;
+  return (
+    <aside className="sidenav">
+      <ul className="sidenav-list">
+        <li key="top" className="sidenav-item">
+          <button
+            type="button"
+            className="sidenav-btn"
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          >
+            Top
+          </button>
+        </li>
+        {items.map((it) => {
+          return (
+            <li key={it.selector} className="sidenav-item">
+              <button
+                type="button"
+                className="sidenav-btn"
+                onClick={() => scrollToId(it.selector)}
+              >
+                <span className="sidenav-label">{it.label}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </aside>
+  );
+}

--- a/src/components/sections/common/SideNav.jsx
+++ b/src/components/sections/common/SideNav.jsx
@@ -1,6 +1,11 @@
+import { useState } from "react";
 import "./SideNav.css";
+import arrowNext from "@assets/icons/arrow-icon-next.svg";
+import arrowPrev from "@assets/icons/arrow-icon-prev.svg";
 
 export default function SideNav({ items = [], offsetTop = 80 }) {
+  const [collapsed, setCollapsed] = useState(false);
+
   const scrollToId = (id) => {
     const el = document.getElementById(id);
     if (!el) return;
@@ -9,31 +14,44 @@ export default function SideNav({ items = [], offsetTop = 80 }) {
   };
 
   return (
-    <aside className="sidenav">
-      <ul className="sidenav-list">
-        <li key="top" className="sidenav-item">
-          <button
-            type="button"
-            className="sidenav-btn"
-            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-          >
-            Top
-          </button>
-        </li>
-        {items.map((it) => {
-          return (
-            <li key={it.selector} className="sidenav-item">
-              <button
-                type="button"
-                className="sidenav-btn"
-                onClick={() => scrollToId(it.selector)}
-              >
-                <span className="sidenav-label">{it.label}</span>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </aside>
+    <>
+      <button
+        type="button"
+        className="sidenav-toggle"
+        onClick={() => setCollapsed((v) => !v)}
+      >
+        {collapsed ? (
+          <img src={arrowPrev} alt="펼치기 버튼" title="펼치기" />
+        ) : (
+          <img src={arrowNext} alt="접기 버튼" title="접기" />
+        )}
+      </button>
+      <aside className={`sidenav ${collapsed ? "sidenav-collapsed" : ""}`}>
+        <ul className="sidenav-list">
+          <li key="top" className="sidenav-item">
+            <button
+              type="button"
+              className="sidenav-btn"
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            >
+              Top
+            </button>
+          </li>
+          {items.map((it) => {
+            return (
+              <li key={it.selector} className="sidenav-item">
+                <button
+                  type="button"
+                  className="sidenav-btn"
+                  onClick={() => scrollToId(it.selector)}
+                >
+                  <span className="sidenav-label">{it.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+    </>
   );
 }

--- a/src/components/sections/common/TrailerModal.jsx
+++ b/src/components/sections/common/TrailerModal.jsx
@@ -29,7 +29,7 @@ export default function TrailerModal({
         <div className="trailer-toolbar">
           {detailBtn ? (
             <Link to={`/movie/${id}`}>
-              <button className="trailer-detail">View Details</button>
+              <button className="hero-detail-btn">MORE INFO</button>
             </Link>
           ) : null}
           <button className="trailer-close" onClick={onClose}>

--- a/src/components/sections/skeleton/DetailHeroSkeleton.jsx
+++ b/src/components/sections/skeleton/DetailHeroSkeleton.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import ContentLoader from "react-content-loader";
+import "./Skeleton.css";
+
+const BackdropSkeleton = () => (
+  <ContentLoader
+    speed={1.6}
+    viewBox="0 0 1280 900"
+    backgroundColor="var(--sk-base-color)"
+    foregroundColor="var(--sk-highlight-color)"
+    className="sk-svg sk-hero-overlay"
+    preserveAspectRatio="none"
+  >
+    <rect x="0" y="0" width="1280" height="900" />
+  </ContentLoader>
+);
+
+const PosterSkeleton = () => (
+  <ContentLoader
+    speed={1.6}
+    viewBox="0 0 300 450"
+    backgroundColor="var(--sk-base-color)"
+    foregroundColor="var(--sk-highlight-color)"
+    className="sk-svg sk-hero-poster"
+    preserveAspectRatio="xMidYMid slice"
+  >
+    <rect x="0" y="0" rx="10" ry="10" width="300" height="450" />
+  </ContentLoader>
+);
+
+const ContentSkeleton = () => (
+  <ContentLoader
+    speed={1.6}
+    viewBox="0 0 560 260"
+    backgroundColor="var(--sk-base-color)"
+    foregroundColor="var(--sk-highlight-color)"
+    className="sk-svg sk-hero-content"
+  >
+    {/* 제목 */}
+    <rect x="0" y="0" rx="6" ry="6" width="380" height="40" />
+
+    {/* 메타 (연령가 · 런타임 · 개봉일) */}
+    <rect x="0" y="58" rx="8" ry="8" width="40" height="20" />
+    <rect x="50" y="58" rx="8" ry="8" width="90" height="20" />
+    <rect x="150" y="58" rx="8" ry="8" width="130" height="20" />
+
+    {/* 태그라인 (한 줄) */}
+    <rect x="0" y="92" rx="5" ry="5" width="200" height="22" />
+
+    {/* 장르 태그 3~4개 */}
+    <rect x="0" y="130" rx="8" ry="8" width="70" height="16" />
+    <rect x="80" y="130" rx="8" ry="8" width="70" height="16" />
+    <rect x="160" y="130" rx="8" ry="8" width="70" height="16" />
+
+    {/* 개요 3~4줄 */}
+    <rect x="0" y="160" rx="5" ry="5" width="380" height="12" />
+    <rect x="0" y="177" rx="5" ry="5" width="380" height="12" />
+    <rect x="0" y="194" rx="5" ry="5" width="380" height="12" />
+
+    {/* 액션 버튼 (트레일러, 즐겨찾기) */}
+    <rect x="0" y="220" rx="5" ry="5" width="120" height="34" />
+    <rect x="140" y="220" rx="99" ry="99" width="34" height="34" />
+  </ContentLoader>
+);
+
+const DetailHeroSkeleton = () => {
+  return (
+    <section className="detail-hero section is-skeleton">
+      {/* 배경 */}
+      <div className="detail-hero__backdrop" aria-hidden="true">
+        <div className="detail-hero__overlay">
+          <BackdropSkeleton />
+        </div>
+      </div>
+
+      <div className="detail-hero__container">
+        {/* 포스터 영역 */}
+        <div className="detail-hero__poster">
+          <PosterSkeleton />
+        </div>
+
+        {/* 본문 영역 */}
+        <div className="detail-hero__content">
+          <ContentSkeleton />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default DetailHeroSkeleton;

--- a/src/components/sections/skeleton/DetailInfoSkeleton.jsx
+++ b/src/components/sections/skeleton/DetailInfoSkeleton.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import ContentLoader from "react-content-loader";
+import "./Skeleton.css";
+
+const Block = ({ w = 500, h = 100, r = 5 }) => (
+  <ContentLoader
+    speed={1.6}
+    viewBox={`0 0 ${w} ${h}`}
+    height={h}
+    backgroundColor="var(--sk-base-color)"
+    foregroundColor="var(--sk-highlight-color)"
+    className="sk-svg"
+  >
+    <rect x="0" y="0" rx={r} ry={r} width={w} height={h} />
+  </ContentLoader>
+);
+
+const DetailInfoSkeleton = () => {
+  return (
+    <section className="detail-info section is-skeleton" aria-busy="true">
+      <div className="info-grid">
+        {/* 상단 */}
+        <div className="info-card">
+          <Block h={100} />
+        </div>
+        <div className="info-card">
+          <Block h={100} />
+        </div>
+
+        {/* 하단 */}
+        <div className="info-card info-card--full">
+          <Block h={50} />
+        </div>
+        <div className="info-card info-card--full">
+          <Block h={50} />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default DetailInfoSkeleton;

--- a/src/components/sections/skeleton/DetailSwiperSkeleton.jsx
+++ b/src/components/sections/skeleton/DetailSwiperSkeleton.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import ContentLoader from "react-content-loader";
+import "./Skeleton.css";
+
+const TabsLine = ({ width = 250, height = 40 }) => (
+  <ContentLoader
+    speed={1.6}
+    viewBox={`0 0 ${width} ${height}`}
+    width={width}
+    height={height}
+    backgroundColor="var(--sk-base-color)"
+    foregroundColor="var(--sk-highlight-color)"
+    className="sk-svg "
+    style={{ width, height }}
+  >
+    <rect x="0" y="0" rx="10" ry="10" width={width} height={height} />
+  </ContentLoader>
+);
+
+const PersonPosterSkeleton = ({ w = 200 }) => {
+  const h = Math.round(w * 1.5); // 2:3
+  return (
+    <ContentLoader
+      speed={1.6}
+      viewBox={`0 0 ${w} ${h}`}
+      width={w}
+      height={h}
+      backgroundColor="var(--sk-base-color)"
+      foregroundColor="var(--sk-highlight-color)"
+      className="sk-svg"
+      style={{ height: h }}
+    >
+      <rect x="0" y="0" rx="10" ry="10" width={w} height={h} />
+    </ContentLoader>
+  );
+};
+
+const DetailSwiperSkeleton = ({ count }) => {
+  return (
+    <section className="detail-people section is-skeleton">
+      <div className="detail-header">
+        <TabsLine width={250} height={40} />
+      </div>
+
+      <div className="people-skeleton-row">
+        {Array.from({ length: count }).map((_, i) => (
+          <div className="people-skeleton-card" key={i}>
+            <PersonPosterSkeleton w={200} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default DetailSwiperSkeleton;

--- a/src/components/sections/skeleton/Skeleton.css
+++ b/src/components/sections/skeleton/Skeleton.css
@@ -45,3 +45,17 @@
 .section.is-skeleton .poster-list--grid {
   margin-top: 50px;
 }
+
+/* People, Media */
+.section.is-skeleton .detail-header {
+  display: flex;
+  justify-content: flex-start;
+}
+.section.is-skeleton .people-skeleton-row {
+  display: flex;
+  gap: 16px;
+  overflow: hidden;
+}
+.section.is-skeleton .people-skeleton-card {
+  flex: 0 0 200px;
+}

--- a/src/components/sections/skeleton/Skeleton.css
+++ b/src/components/sections/skeleton/Skeleton.css
@@ -4,7 +4,7 @@
 
 .sk-svg {
   width: 100%;
-  height: 100%;
+  height: auto;
   display: block;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,7 @@
   --color-gray-300: #9aa0a6;
 
   /* Backgrounds */
+  --bg: #0f0f0f;
   --bg-overlay: rgba(0, 0, 0, 1);
   --bg-header: linear-gradient(
     to bottom,
@@ -35,6 +36,7 @@
   --z-hero-overlay: 100;
   --z-hero-content: 101;
   --z-trailer-modal: 500;
+  --z-sidenav: 550;
   --z-dropdown: 600;
   --z-header: 1000;
 
@@ -55,7 +57,7 @@ html,
 body {
   font-family: "Pretendard", "Noto Sans KR", sans-serif;
   color: #ffffff;
-  background-color: #0f0f0f;
+  background-color: var(--bg);
 }
 
 a {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -15,9 +15,9 @@ const Home = () => {
 
       <SideNav
         items={[
-          { label: "Trending", selector: "#trending" },
-          { label: "Now Playing", selector: "#now-playing" },
-          { label: "Upcoming", selector: "#upcoming" },
+          { label: "Trending", selector: "trending" },
+          { label: "Now Playing", selector: "now-playing" },
+          { label: "Upcoming", selector: "upcoming" },
         ]}
       />
     </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -15,9 +15,9 @@ const Home = () => {
 
       <SideNav
         items={[
-          { label: "Trending", selector: "trending" },
-          { label: "Now Playing", selector: "now-playing" },
-          { label: "Upcoming", selector: "upcoming" },
+          { label: "Trending", short: "Trend", selector: "trending" },
+          { label: "Now Playing", short: "Now", selector: "now-playing" },
+          { label: "Upcoming", short: "Soon", selector: "upcoming" },
         ]}
       />
     </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,14 +3,23 @@ import HeroSection from "@components/sections/HeroSection/HeroSection";
 import TrendingSection from "@components/sections/TrendingSection/TrendingSection";
 import NowPlayingSection from "@components/sections/NowPlayingSection/NowPlayingSection";
 import UpcomingSection from "@components/sections/UpcomingSection/UpcomingSection";
+import SideNav from "@/components/sections/common/SideNav";
 
 const Home = () => {
   return (
     <div>
       <HeroSection />
-      <TrendingSection />
-      <NowPlayingSection />
-      <UpcomingSection />
+      <TrendingSection id="trending" />
+      <NowPlayingSection id="now-playing" />
+      <UpcomingSection id="upcoming" />
+
+      <SideNav
+        items={[
+          { label: "Trending", selector: "#trending" },
+          { label: "Now Playing", selector: "#now-playing" },
+          { label: "Upcoming", selector: "#upcoming" },
+        ]}
+      />
     </div>
   );
 };

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -10,6 +10,7 @@ import DetailMedia from "@components/sections/DetailSection/DetailMedia/DetailMe
 import DetailInfo from "@components/sections/DetailSection/DetailInfo/DetailInfo";
 import Recommendation from "@/components/sections/DetailSection/DetailRelated/DetailRecommended";
 import DetailCollection from "@/components/sections/DetailSection/DetailRelated/DetailCollection";
+import SideNav from "@/components/sections/common/SideNav";
 
 const MovieDetail = () => {
   const { id } = useParams();
@@ -68,13 +69,13 @@ const MovieDetail = () => {
       <DetailCollection anchorId="collection" movieId={id} />
       <Recommendation anchorId="recommended" movieId={id} />
 
-      <SideDockNav
+      <SideNav
         items={[
-          { label: "People", selector: "#people" },
-          { label: "Media", selector: "#media" },
-          { label: "Info", selector: "#info" },
-          { label: "Collection", selector: "#collection" },
-          { label: "Recommended", selector: "#recommended" },
+          { label: "People", selector: "people" },
+          { label: "Media", selector: "media" },
+          { label: "Info", selector: "info" },
+          { label: "Collection", selector: "collection" },
+          { label: "Recommended", selector: "recommended" },
         ]}
       />
     </div>

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -71,11 +71,11 @@ const MovieDetail = () => {
 
       <SideNav
         items={[
-          { label: "People", selector: "people" },
-          { label: "Media", selector: "media" },
-          { label: "Info", selector: "info" },
-          { label: "Collection", selector: "collection" },
-          { label: "Recommended", selector: "recommended" },
+          { label: "People", short: "People", selector: "people" },
+          { label: "Media", short: "Media", selector: "media" },
+          { label: "Info", short: "Info", selector: "info" },
+          { label: "Collection", short: "Coll.", selector: "collection" },
+          { label: "Recommended", short: "Rec.", selector: "recommended" },
         ]}
       />
     </div>

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -11,6 +11,9 @@ import DetailInfo from "@components/sections/DetailSection/DetailInfo/DetailInfo
 import Recommendation from "@/components/sections/DetailSection/DetailRelated/DetailRecommended";
 import DetailCollection from "@/components/sections/DetailSection/DetailRelated/DetailCollection";
 import SideNav from "@/components/sections/common/SideNav";
+import DetailHeroSkeleton from "@components/sections/skeleton/DetailHeroSkeleton";
+import DetailInfoSkeleton from "@components/sections/skeleton/DetailInfoSkeleton";
+import DetailSwiperSkeleton from "@/components/sections/skeleton/DetailSwiperSkeleton";
 
 const MovieDetail = () => {
   const { id } = useParams();
@@ -33,12 +36,15 @@ const MovieDetail = () => {
 
   const sortedCrew = sortCrew(detail?.credits?.crew ?? []);
 
-  if (loading) return <div>로딩 중...</div>;
-  if (!detail) return <div>영화 정보를 불러올 수 없습니다.</div>;
+  if (!loading && !detail) return <div>영화 정보를 불러올 수 없습니다.</div>;
 
   return (
     <div>
-      <DetailHero detail={detail} onPlayTrailer={() => handlePlay()} />
+      {loading ? (
+        <DetailHeroSkeleton />
+      ) : (
+        <DetailHero detail={detail} onPlayTrailer={() => handlePlay()} />
+      )}
 
       {isOpen && (
         <TrailerModal
@@ -50,21 +56,33 @@ const MovieDetail = () => {
         />
       )}
 
-      <DetailPeople
-        anchorId="people"
-        cast={detail?.credits?.cast ?? []}
-        crew={sortedCrew ?? []}
-      />
+      {loading ? (
+        <DetailSwiperSkeleton count={7} />
+      ) : (
+        <DetailPeople
+          anchorId="people"
+          cast={detail?.credits?.cast ?? []}
+          crew={sortedCrew ?? []}
+        />
+      )}
 
-      <DetailMedia
-        anchorId="media"
-        videos={detail?.videos?.results ?? []}
-        backdrops={detail?.images?.backdrops ?? []}
-        posters={detail?.images?.posters ?? []}
-        onPlay={handlePlay}
-      />
+      {loading ? (
+        <DetailSwiperSkeleton count={7} />
+      ) : (
+        <DetailMedia
+          anchorId="media"
+          videos={detail?.videos?.results ?? []}
+          backdrops={detail?.images?.backdrops ?? []}
+          posters={detail?.images?.posters ?? []}
+          onPlay={handlePlay}
+        />
+      )}
 
-      <DetailInfo anchorId="info" detail={detail} />
+      {loading ? (
+        <DetailInfoSkeleton />
+      ) : (
+        <DetailInfo anchorId="info" detail={detail} />
+      )}
 
       <DetailCollection anchorId="collection" movieId={id} />
       <Recommendation anchorId="recommended" movieId={id} />

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -50,21 +50,33 @@ const MovieDetail = () => {
       )}
 
       <DetailPeople
+        anchorId="people"
         cast={detail?.credits?.cast ?? []}
         crew={sortedCrew ?? []}
       />
 
       <DetailMedia
+        anchorId="media"
         videos={detail?.videos?.results ?? []}
         backdrops={detail?.images?.backdrops ?? []}
         posters={detail?.images?.posters ?? []}
         onPlay={handlePlay}
       />
 
-      <DetailInfo detail={detail} />
+      <DetailInfo anchorId="info" detail={detail} />
 
-      <DetailCollection id={id} />
-      <Recommendation id={id} />
+      <DetailCollection anchorId="collection" movieId={id} />
+      <Recommendation anchorId="recommended" movieId={id} />
+
+      <SideDockNav
+        items={[
+          { label: "People", selector: "#people" },
+          { label: "Media", selector: "#media" },
+          { label: "Info", selector: "#info" },
+          { label: "Collection", selector: "#collection" },
+          { label: "Recommended", selector: "#recommended" },
+        ]}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### 👀 구현 화면
- DetailHero
<img width="1017" height="467" alt="스크린샷 2025-11-04 112030" src="https://github.com/user-attachments/assets/60cb3080-f82d-425e-b069-a3b51597cda6" />

- DetailInfo
<img width="918" height="418" alt="스크린샷 2025-11-04 112055" src="https://github.com/user-attachments/assets/ba960358-d87a-4cee-bbec-8cd635f383ad" />

---

### ✅ 변경사항  

#### 1. HeroSection  
- **디테일 페이지 이동 버튼 추가**  
  - 트레일러 외에도 상세 페이지(`/movie/:id`)로 이동 가능한 버튼 추가  

#### 2. Home / Detail 섹션 ID 구조 정비  
- **Home 섹션별 `id` 추가** → SideNav 내 앵커 스크롤 연결  
- **Detail 섹션별 `anchorId` 추가** → 내부 앵커 네비게이션 기능 구현  

#### 3. SideNav 기능 구현  
- **기본 레이아웃 및 UI 구성**  
  - 화면 오른쪽 고정 위치에 섹션 네비게이션 표시  
- **접기/펼치기 토글 기능 추가**  
  - 클릭 시 사이드바 숨김/표시 토글  
- **1024px 이하 반응형 구현**  
  - `display: none` 대신 섹션명 축약어로 표시되도록 구현  

#### 4. Detail 페이지 스켈레톤 UI 적용  
- **각 섹션별 스켈레톤 컴포넌트 구현 및 연결**
- **MovieDetail 페이지에 스켈레톤 연결**
  - 데이터 로딩 중 해당 스켈레톤 컴포넌트 렌더링  
