### PR TITLE
[Feat] 즐겨찾기 기능 구현 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import MovieDetail from "@pages/MovieDetail";
 import ScrollToTop from "@components/sections/common/ScrollToTop";
 import GenreList from "./pages/GenreList";
 import "./App.css";
+import MyPage from "./pages/MyPage";
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
             <Route path="/search" element={<SearchResult />} />
             <Route path="/movie/:id" element={<MovieDetail />} />
             <Route path="/genre/:genreId" element={<GenreList />} />
+            <Route path="/mypage" element={<MyPage />} />
           </Routes>
         </main>
         <Footer />

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -32,9 +32,9 @@ const Header = () => {
           <img src={searchIcon} alt="검색 버튼" />
         </button>
       </form>
-      <button className="user-btn">
+      <Link to="/mypage" className="user-btn">
         <img src={avatarIcon} alt="사용자 프로필" />
-      </button>
+      </Link>
     </div>
   );
 };

--- a/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
+++ b/src/components/sections/DetailSection/DetailHero/DetailHero.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import GenreTags from "@/components/sections/common/GenreTags";
 import { formatRuntime, formatDate, pickCertification } from "@utils/format";
+import { toggleFavoriteMovie, isFavoriteMovie } from "@utils/favorites";
 import playIcon from "@assets/icons/play.svg";
 import noPoster from "@assets/poster-default.svg";
 import quoteOpen from "@assets/icons/quote-open.png";
@@ -11,6 +12,13 @@ import "./DetailHero.css";
 
 const DetailHero = ({ detail, onPlayTrailer }) => {
   const [isFavorite, setIsFavorite] = useState(false);
+  const movieId = detail?.id;
+
+  useEffect(() => {
+    if (!movieId) return;
+    setIsFavorite(isFavoriteMovie(movieId));
+  }, [movieId]);
+
   if (!detail) return null;
 
   const {
@@ -37,6 +45,11 @@ const DetailHero = ({ detail, onPlayTrailer }) => {
   const posterUrl = poster_path
     ? `https://image.tmdb.org/t/p/original${poster_path}`
     : noPoster;
+
+  const handleToggleFavorite = () => {
+    toggleFavoriteMovie(detail);
+    setIsFavorite((prev) => !prev);
+  };
 
   return (
     <section className="detail-hero">
@@ -104,7 +117,7 @@ const DetailHero = ({ detail, onPlayTrailer }) => {
             <button
               type="button"
               className={`hero-fav-btn ${isFavorite ? "active" : ""}`}
-              onClick={() => setIsFavorite(!isFavorite)}
+              onClick={handleToggleFavorite}
             >
               <img
                 src={isFavorite ? favFilled : favOutline}

--- a/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
@@ -8,8 +8,6 @@ import SectionCard from "@components/sections/common/SectionCard";
 import { useCollectionMovies } from "@/hooks/useCollectionMovies";
 import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
-import release from "@assets/icons/release.svg";
-import vote from "@assets/icons/vote.svg";
 
 const DetailCollection = ({ anchorId, movieId }) => {
   const { collection, parts, loading } = useCollectionMovies(movieId);
@@ -73,9 +71,13 @@ const DetailCollection = ({ anchorId, movieId }) => {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
-                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: vote,
+                    icon: "/src/assets/icons/release.svg",
+                    text: movie.release_date,
+                    alt: "개봉일",
+                  },
+                  {
+                    icon: "/src/assets/icons/vote.svg",
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailCollection.jsx
@@ -9,6 +9,9 @@ import { useCollectionMovies } from "@/hooks/useCollectionMovies";
 import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
 const DetailCollection = ({ anchorId, movieId }) => {
   const { collection, parts, loading } = useCollectionMovies(movieId);
 
@@ -71,13 +74,9 @@ const DetailCollection = ({ anchorId, movieId }) => {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: "/src/assets/icons/release.svg",
-                    text: movie.release_date,
-                    alt: "개봉일",
-                  },
-                  {
-                    icon: "/src/assets/icons/vote.svg",
+                    icon: vote,
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
@@ -9,6 +9,9 @@ import { useRecommendationMovies } from "@hooks/useRecommendationMovies";
 import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
 export default function DetailRecommended({ anchorId, movieId }) {
   const { data, loading } = useRecommendationMovies(movieId);
 
@@ -63,13 +66,9 @@ export default function DetailRecommended({ anchorId, movieId }) {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: "/src/assets/icons/release.svg",
-                    text: movie.release_date,
-                    alt: "개봉일",
-                  },
-                  {
-                    icon: "/src/assets/icons/vote.svg",
+                    icon: vote,
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
+++ b/src/components/sections/DetailSection/DetailRelated/DetailRecommended.jsx
@@ -8,8 +8,6 @@ import SectionCard from "@components/sections/common/SectionCard";
 import { useRecommendationMovies } from "@hooks/useRecommendationMovies";
 import { getDDay } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
-import release from "@assets/icons/release.svg";
-import vote from "@assets/icons/vote.svg";
 
 export default function DetailRecommended({ anchorId, movieId }) {
   const { data, loading } = useRecommendationMovies(movieId);
@@ -65,9 +63,13 @@ export default function DetailRecommended({ anchorId, movieId }) {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
-                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: vote,
+                    icon: "/src/assets/icons/release.svg",
+                    text: movie.release_date,
+                    alt: "개봉일",
+                  },
+                  {
+                    icon: "/src/assets/icons/vote.svg",
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/GenreSection/GenreSection.css
+++ b/src/components/sections/GenreSection/GenreSection.css
@@ -1,19 +1,3 @@
-.section.genre {
-  margin-top: 100px;
-}
-
-@media (max-width: 767px) {
-  .genre .section-info {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-  }
-  .genre .section-desc,
-  .genre .section-page {
-    width: 100%;
-  }
-}
-
 .genre-filter {
   display: grid;
   gap: 12px;
@@ -32,4 +16,16 @@
   border: 1px solid var(--color-gray-200);
   border-radius: 5px;
   font-size: 13px;
+}
+
+@media (max-width: 767px) {
+  .genre .section-info {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .genre .section-desc,
+  .genre .section-page {
+    width: 100%;
+  }
 }

--- a/src/components/sections/GenreSection/GenreSection.jsx
+++ b/src/components/sections/GenreSection/GenreSection.jsx
@@ -12,6 +12,9 @@ import { getDDay } from "@utils/format";
 import { parseGenres, writeGenres, toggleGenreParam } from "@utils/genresQuery";
 import { useGenres } from "@hooks/useGenres";
 
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
 export default function GenreSection() {
   const { genreId } = useParams();
   const [params, setParams] = useSearchParams();
@@ -149,13 +152,9 @@ export default function GenreSection() {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: "/src/assets/icons/release.svg",
-                    text: movie.release_date || "-",
-                    alt: "개봉일",
-                  },
-                  {
-                    icon: "/src/assets/icons/vote.svg",
+                    icon: vote,
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/GenreSection/GenreSection.jsx
+++ b/src/components/sections/GenreSection/GenreSection.jsx
@@ -86,7 +86,7 @@ export default function GenreSection() {
   if (loading) return <p>불러오는 중...</p>;
 
   return (
-    <section className="genre section">
+    <section className="section list">
       <SectionHeader
         title={titleText}
         desc={

--- a/src/components/sections/SearchSection/SearchSection.css
+++ b/src/components/sections/SearchSection/SearchSection.css
@@ -1,7 +1,3 @@
-.section.search {
-  margin-top: 100px;
-}
-
 .poster-list--grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));

--- a/src/components/sections/SearchSection/SearchSection.jsx
+++ b/src/components/sections/SearchSection/SearchSection.jsx
@@ -11,6 +11,9 @@ import "./SearchSection.css";
 import SearchSkeleton from "@components/sections/skeleton/SearchSkeleton";
 import { getDDay } from "@utils/format";
 
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
 const SearchSection = () => {
   const [params, setParams] = useSearchParams();
   const query = params.get("q") ?? "";
@@ -103,13 +106,9 @@ const SearchSection = () => {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: "/src/assets/icons/release.svg",
-                    text: movie.release_date || "-",
-                    alt: "개봉일",
-                  },
-                  {
-                    icon: "/src/assets/icons/vote.svg",
+                    icon: vote,
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/SearchSection/SearchSection.jsx
+++ b/src/components/sections/SearchSection/SearchSection.jsx
@@ -54,7 +54,7 @@ const SearchSection = () => {
   }
 
   return (
-    <section className="section search">
+    <section className="section list">
       <SectionHeader
         title={`"${query}" 관련 영화`}
         desc={

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -11,8 +11,6 @@ import SectionHeader from "@components/sections/common/SectionHeader";
 import SectionCard from "@components/sections/common/SectionCard";
 import { formatRuntime } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
-import vote from "@assets/icons/vote.svg";
-import runtime from "@assets/icons/runtime.svg";
 
 const TrendingSection = ({ id }) => {
   const [period, setPeriod] = useState("day");
@@ -73,12 +71,12 @@ const TrendingSection = ({ id }) => {
                 title={movie.title}
                 meta={[
                   {
-                    icon: runtime,
+                    icon: "/src/assets/icons/runtime.svg",
                     text: formatRuntime(movie.runtime),
                     alt: "런타임",
                   },
                   {
-                    icon: vote,
+                    icon: "/src/assets/icons/vote.svg",
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/TrendingSection/TrendingSection.jsx
+++ b/src/components/sections/TrendingSection/TrendingSection.jsx
@@ -12,6 +12,9 @@ import SectionCard from "@components/sections/common/SectionCard";
 import { formatRuntime } from "@utils/format";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 
+import vote from "@assets/icons/vote.svg";
+import runtime from "@assets/icons/runtime.svg";
+
 const TrendingSection = ({ id }) => {
   const [period, setPeriod] = useState("day");
   const { data, loading } = useTrendingMoviesWithRuntime(period);
@@ -71,12 +74,12 @@ const TrendingSection = ({ id }) => {
                 title={movie.title}
                 meta={[
                   {
-                    icon: "/src/assets/icons/runtime.svg",
+                    icon: runtime,
                     text: formatRuntime(movie.runtime),
                     alt: "런타임",
                   },
                   {
-                    icon: "/src/assets/icons/vote.svg",
+                    icon: vote,
                     text: (movie.vote_average ?? 0).toFixed(1),
                     alt: "평점",
                   },

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -10,6 +10,9 @@ import SectionHeader from "@components/sections/common/SectionHeader";
 import SectionCard from "@components/sections/common/SectionCard";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 
+import release from "@assets/icons/release.svg";
+import popularity from "@assets/icons/popularity.svg";
+
 const UpcomingSection = ({ id }) => {
   const { data, loading } = useUpcomingMovies();
   if (loading) return <SwiperSkeleton count={5} />;
@@ -51,13 +54,9 @@ const UpcomingSection = ({ id }) => {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
+                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: "/src/assets/icons/release.svg",
-                    text: movie.release_date,
-                    alt: "개봉일",
-                  },
-                  {
-                    icon: "/src/assets/icons/popularity.svg",
+                    icon: popularity,
                     text: Math.round(movie.popularity),
                     alt: "인기도",
                   },

--- a/src/components/sections/UpcomingSection/UpcomingSection.jsx
+++ b/src/components/sections/UpcomingSection/UpcomingSection.jsx
@@ -10,9 +10,6 @@ import SectionHeader from "@components/sections/common/SectionHeader";
 import SectionCard from "@components/sections/common/SectionCard";
 import SwiperSkeleton from "@components/sections/skeleton/SwiperSkeleton";
 
-import release from "@assets/icons/release.svg";
-import popularity from "@assets/icons/popularity.svg";
-
 const UpcomingSection = ({ id }) => {
   const { data, loading } = useUpcomingMovies();
   if (loading) return <SwiperSkeleton count={5} />;
@@ -54,9 +51,13 @@ const UpcomingSection = ({ id }) => {
                 title={movie.title}
                 badge={movie.release_date ? getDDay(movie.release_date) : null}
                 meta={[
-                  { icon: release, text: movie.release_date, alt: "개봉일" },
                   {
-                    icon: popularity,
+                    icon: "/src/assets/icons/release.svg",
+                    text: movie.release_date,
+                    alt: "개봉일",
+                  },
+                  {
+                    icon: "/src/assets/icons/popularity.svg",
                     text: Math.round(movie.popularity),
                     alt: "인기도",
                   },

--- a/src/components/sections/common/Pagination.jsx
+++ b/src/components/sections/common/Pagination.jsx
@@ -28,7 +28,7 @@ const Pagination = ({ page, totalPages, onChange }) => {
   };
 
   return (
-    <nav className="pagination" aria-label="검색 결과 페이지네이션">
+    <nav className="pagination" aria-label="결과 페이지네이션">
       <button
         className="pagination-btn"
         onClick={() => go(page - 1)}

--- a/src/components/sections/common/Section.css
+++ b/src/components/sections/common/Section.css
@@ -3,6 +3,10 @@
   padding: 50px 100px;
 }
 
+.section.list {
+  margin-top: 100px;
+}
+
 .section-header {
   display: flex;
   align-items: flex-end;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -2,13 +2,22 @@ import { useEffect, useState } from "react";
 import { getFavoriteMovies } from "@utils/favorites";
 import SectionCard from "@components/sections/common/SectionCard";
 import SectionHeader from "@/components/sections/common/SectionHeader";
+import Pagination from "@/components/sections/common/Pagination";
+
+const PAGE_SIZE = 20;
 
 const MyPage = () => {
   const [favorites, setFavorites] = useState(() => getFavoriteMovies());
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     setFavorites(getFavoriteMovies());
+    setPage(1);
   }, []);
+
+  const totalPages = Math.ceil(favorites.length / PAGE_SIZE) || 1;
+  const startIndex = (page - 1) * PAGE_SIZE;
+  const pagedFavorites = favorites.slice(startIndex, startIndex + PAGE_SIZE);
 
   return (
     <section className="section list">
@@ -23,11 +32,12 @@ const MyPage = () => {
             개의 즐겨찾기한 영화가 존재합니다.
           </>
         }
+        pageInfo={`${page} / ${totalPages} 페이지`}
         hasNav={false}
       />
 
       <div className="poster-list--grid">
-        {favorites.map((movie) => (
+        {pagedFavorites.map((movie) => (
           <SectionCard
             key={movie.id}
             id={movie.id}
@@ -48,6 +58,8 @@ const MyPage = () => {
           />
         ))}
       </div>
+
+      <Pagination page={page} totalPages={totalPages} onChange={setPage} />
     </section>
   );
 };

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -4,6 +4,9 @@ import SectionCard from "@components/sections/common/SectionCard";
 import SectionHeader from "@/components/sections/common/SectionHeader";
 import Pagination from "@/components/sections/common/Pagination";
 
+import release from "@assets/icons/release.svg";
+import vote from "@assets/icons/vote.svg";
+
 const PAGE_SIZE = 20;
 
 const MyPage = () => {
@@ -44,13 +47,9 @@ const MyPage = () => {
             posterPath={movie.poster_path}
             title={movie.title}
             meta={[
+              { icon: release, text: movie.release_date, alt: "개봉일" },
               {
-                icon: "/src/assets/icons/release.svg",
-                text: movie.release_date || "-",
-                alt: "개봉일",
-              },
-              {
-                icon: "/src/assets/icons/vote.svg",
+                icon: vote,
                 text: (movie.vote_average ?? 0).toFixed(1),
                 alt: "평점",
               },

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { getFavoriteMovies } from "@utils/favorites";
+import SectionCard from "@components/sections/common/SectionCard";
+import SectionHeader from "@/components/sections/common/SectionHeader";
+
+const MyPage = () => {
+  const [favorites, setFavorites] = useState(() => getFavoriteMovies());
+
+  useEffect(() => {
+    setFavorites(getFavoriteMovies());
+  }, []);
+
+  return (
+    <section className="section list">
+      <SectionHeader
+        title="Favorite Movies"
+        desc={
+          <>
+            총{" "}
+            <span className="highlight">
+              {favorites.length.toLocaleString()}
+            </span>
+            개의 즐겨찾기한 영화가 존재합니다.
+          </>
+        }
+        hasNav={false}
+      />
+
+      <div className="poster-list--grid">
+        {favorites.map((movie) => (
+          <SectionCard
+            key={movie.id}
+            id={movie.id}
+            posterPath={movie.poster_path}
+            title={movie.title}
+            meta={[
+              {
+                icon: "/src/assets/icons/release.svg",
+                text: movie.release_date || "-",
+                alt: "개봉일",
+              },
+              {
+                icon: "/src/assets/icons/vote.svg",
+                text: (movie.vote_average ?? 0).toFixed(1),
+                alt: "평점",
+              },
+            ]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default MyPage;

--- a/src/utils/favorites.js
+++ b/src/utils/favorites.js
@@ -1,0 +1,33 @@
+const STORAGE_KEY = "favorite-movies";
+
+export function getFavoriteMovies() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveFavoriteMovies(movies) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(movies));
+}
+
+// 영화 토글 (추가/삭제)
+export function toggleFavoriteMovie(movie) {
+  const current = getFavoriteMovies();
+  const exists = current.some((item) => item.id === movie.id);
+
+  const next = exists
+    ? current.filter((item) => item.id !== movie.id)
+    : [...current, movie];
+
+  saveFavoriteMovies(next);
+  return next;
+}
+
+// 해당 영화가 즐겨찾기인지 체크
+export function isFavoriteMovie(id) {
+  const current = getFavoriteMovies();
+  return current.some((item) => item.id === id);
+}


### PR DESCRIPTION
### 👀 구현 화면
<img width="851" height="644" alt="image" src="https://github.com/user-attachments/assets/6c97b968-15bb-408e-8503-5926fe06882f" />

### ✅ 변경사항
#### 1. MyPage 즐겨찾기 기능 구현
- 즐겨찾기한 영화들을 MyPage에서 전용 그리드로 렌더링
- 페이지 상단에 즐겨찾기 영화 총 개수 표시
- MovieDetail → MyPage 간 데이터 구조 정리

#### 2. 즐겨찾기 유틸 함수 추가 (`utils/favorites.js`)
- `getFavoriteMovies`, `toggleFavoriteMovie`, `isFavoriteMovie` 유틸 구현
- localStorage 기반의 즐겨찾기 저장/삭제/조회 로직 완성
- DetailHero 및 MyPage에서 공통 사용 가능하도록 분리

#### 3. DetailHero 즐겨찾기 토글 연동
- detail 객체 기반으로 즐겨찾기 토글 가능
- 초기값 localStorage 동기화 처리

#### 4. MyPage Pagination 기능 추가
- 한 페이지당 20개 렌더링
- 공통 Pagination 컴포넌트 재사용
- `page / totalPages 페이지` 정보 SectionHeader와 연동